### PR TITLE
refactor: Remove persistent, transient intent distinction. Minor essential-types refactor.

### DIFF
--- a/crates/types/src/convert.rs
+++ b/crates/types/src/convert.rs
@@ -1,6 +1,6 @@
 //! Helper functions for converting between byte and word representations.
 
-use crate::{IntentAddress, Word};
+use crate::{ContentAddress, Word};
 
 /// Convert a `Word` to its bytes.
 pub fn bytes_from_word(w: Word) -> [u8; 8] {
@@ -49,20 +49,20 @@ pub fn u8_32_from_word_4(words: [Word; 4]) -> [u8; 32] {
     ]
 }
 
-impl From<IntentAddress> for [Word; 4] {
-    fn from(address: IntentAddress) -> Self {
+impl From<ContentAddress> for [Word; 4] {
+    fn from(address: ContentAddress) -> Self {
         word_4_from_u8_32(address.0)
     }
 }
 
-impl From<[Word; 4]> for IntentAddress {
+impl From<[Word; 4]> for ContentAddress {
     fn from(address: [Word; 4]) -> Self {
         Self(u8_32_from_word_4(address))
     }
 }
 
-impl From<IntentAddress> for [u8; 32] {
-    fn from(address: IntentAddress) -> Self {
+impl From<ContentAddress> for [u8; 32] {
+    fn from(address: ContentAddress) -> Self {
         address.0
     }
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -17,13 +17,6 @@ pub type ConstraintBytecode = Vec<u8>;
 /// State read code serialized as json.
 pub type StateReadBytecode = Vec<u8>;
 
-/// Hash encoded as a 32 byte array.
-pub type Hash = [u8; 32];
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-/// Content address of an intent or set of intents.
-pub struct IntentAddress(pub Hash);
-
 /// Single unit of data.
 pub type Word = i64;
 
@@ -33,53 +26,23 @@ pub type Key = [Word; 4];
 /// Range of keys for state data.
 pub type KeyRange = Range<Key>;
 
+/// Hash encoded as a 32 byte array.
+pub type Hash = [u8; 32];
+
 /// Externally owned account.
+///
 /// Note this type will likely change in the future.
-pub type Eoa = [Word; 4];
+pub type Eoa = [u8; 32];
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+/// Content address of an intent or set of intents.
+pub struct ContentAddress(pub Hash);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 /// Address of a persistent intent.
-pub struct PersistentAddress {
+pub struct IntentAddress {
     /// Content address of the set of intents that this intent is deployed with.
-    pub set: IntentAddress,
+    pub set: ContentAddress,
     /// Content address of the intent.
-    pub intent: IntentAddress,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-/// The address of an intent.
-pub enum SourceAddress {
-    /// Transient intent content address.
-    Transient(IntentAddress),
-    /// Persistent intent content address.
-    Persistent(PersistentAddress),
-}
-
-impl SourceAddress {
-    /// Construct a persistent source address.
-    pub fn persistent(set: IntentAddress, intent: IntentAddress) -> Self {
-        SourceAddress::Persistent(PersistentAddress { set, intent })
-    }
-
-    /// Construct a transient source address.
-    pub fn transient(intent: IntentAddress) -> Self {
-        SourceAddress::Transient(intent)
-    }
-
-    /// Get the content address of the set of intents that this intent is deployed with.
-    /// For transient intents, this is the same as the intent address.
-    pub fn set_address(&self) -> &IntentAddress {
-        match self {
-            SourceAddress::Transient(intent) => intent,
-            SourceAddress::Persistent(persistent) => &persistent.set,
-        }
-    }
-
-    /// Get the content address of the actual intent.
-    pub fn intent_address(&self) -> &IntentAddress {
-        match self {
-            SourceAddress::Transient(intent) => intent,
-            SourceAddress::Persistent(persistent) => &persistent.intent,
-        }
-    }
+    pub intent: ContentAddress,
 }


### PR DESCRIPTION
This allows us to make the following renames:

- `IntentAddress` -> `ContentAddress`
- `SourceAddress` -> `IntentAddress`

Adds the `ForwardedEoaSender` type, for the case where an EOA has been forwarded by an intent.

The `Eoa` type alias has also been changed from `[Word; 4]` to `[u8; 32]`, though may change again pending #19.

Closes #1
Closes #13