### PR TITLE
Chore: Remove `serde_json`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,6 @@ version = "0.1.0"
 dependencies = [
  "essential-types",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -17,7 +16,6 @@ version = "0.1.0"
 dependencies = [
  "essential-constraint-asm",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -25,14 +23,7 @@ name = "essential-types"
 version = "0.1.0"
 dependencies = [
  "serde",
- "serde_json",
 ]
-
-[[package]]
-name = "itoa"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "proc-macro2"
@@ -53,12 +44,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
-
-[[package]]
 name = "serde"
 version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,17 +61,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.113"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,5 @@ essential-constraint-asm = { path = "crates/constraint-asm" }
 essential-state-asm = { path = "crates/state-asm" }
 essential-types = { path = "crates/types" }
 hex = "0.4.3"
-# TODO: essential-contributions/specs#50 - replace serialization.
 serde = { version = "1.0.195", features = ["derive"] }
-serde_json = "1.0.111"
 tempfile = "3.9.0"

--- a/crates/constraint-asm/Cargo.toml
+++ b/crates/constraint-asm/Cargo.toml
@@ -6,4 +6,3 @@ version = "0.1.0"
 [dependencies]
 essential-types.workspace = true
 serde.workspace = true
-serde_json.workspace = true

--- a/crates/state-asm/Cargo.toml
+++ b/crates/state-asm/Cargo.toml
@@ -6,4 +6,3 @@ version = "0.1.0"
 [dependencies]
 essential-constraint-asm.workspace = true
 serde.workspace = true
-serde_json.workspace = true

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -5,4 +5,3 @@ version = "0.1.0"
 
 [dependencies]
 serde.workspace = true
-serde_json.workspace = true


### PR DESCRIPTION
Removing serde_json dependency as it is not currently used, and will not be used

Refs #5 (Issue closed by https://github.com/essential-contributions/essential-server/pull/19)
