### PR TITLE
Upstream `essential-constraint-vm` and `essential-state-read-vm` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,201 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "autocfg"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+
+[[package]]
+name = "backtrace"
+version = "0.3.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "either"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "equivalent"
@@ -43,6 +234,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "essential-constraint-vm"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "essential-constraint-asm",
+ "essential-types",
+ "rand",
+ "rayon",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "essential-state-asm"
 version = "0.1.0"
 dependencies = [
@@ -52,12 +256,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "essential-state-read-vm"
+version = "0.1.0"
+dependencies = [
+ "essential-constraint-vm",
+ "essential-state-asm",
+ "essential-types",
+ "futures",
+ "rand",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "essential-types"
 version = "0.1.0"
 dependencies = [
  "schemars",
  "serde",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+
+[[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "hashbrown"
@@ -82,6 +421,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "libc"
+version = "0.2.153"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "memchr"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "platforms"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +500,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -128,6 +596,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
@@ -185,6 +659,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +726,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "tokio"
+version = "1.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,3 +784,21 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,16 +6,25 @@ resolver = "2"
 edition = "2021"
 
 [workspace.dependencies]
+ed25519-dalek = "2.1.0"
 essential-asm-gen = { path = "crates/asm-gen" }
 essential-asm-spec = { path = "crates/asm-spec" }
 essential-constraint-asm = { path = "crates/constraint-asm" }
+essential-constraint-vm = { path = "crates/constraint-vm" }
 essential-state-asm = { path = "crates/state-asm" }
+essential-state-read-vm = { path = "crates/state-read-vm" }
 essential-types = { path = "crates/types" }
+futures = "0.3" # For `state-read-vm` tests.
 hex = "0.4.3"
 proc-macro2 = "1"
 quote = "1"
+rand = { version = "0.8", features = ["small_rng"] } # For VM tests.
+rayon = "1" # For `constraint-vm` parallelisation.
 schemars = "0.8.16"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_yaml = "0.9"
+sha2 = "0.10.8"
 syn = { version = "2", features = ["extra-traits", "full", "printing"] }
 tempfile = "3.9.0"
+thiserror = "1"
+tokio = { version = "1.36", default-features = false, features = ["macros", "test-util"] } # Used for `state-read-vm` tests.

--- a/crates/constraint-vm/Cargo.toml
+++ b/crates/constraint-vm/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "essential-constraint-vm"
+version = "0.1.0"
+edition = "2021"
+description = "The Essential constraint checking VM"
+
+[dependencies]
+ed25519-dalek = { workspace = true }
+essential-constraint-asm = { workspace = true }
+essential-types = { workspace = true }
+rayon = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+rand = { workspace = true }

--- a/crates/constraint-vm/src/access.rs
+++ b/crates/constraint-vm/src/access.rs
@@ -1,0 +1,660 @@
+//! Access operation implementations.
+
+use crate::{error::AccessError, types::convert::bool_from_word, OpResult, Stack};
+use essential_constraint_asm::Word;
+use essential_types::{
+    convert::word_4_from_u8_32,
+    solution::{DecisionVariable, SolutionData},
+};
+
+/// All necessary solution data and state access required to check an individual intent.
+#[derive(Clone, Copy, Debug)]
+pub struct Access<'a> {
+    /// All necessary solution data access required to check an individual intent.
+    pub solution: SolutionAccess<'a>,
+    /// The pre and post mutation state slot values for the intent being solved.
+    pub state_slots: StateSlots<'a>,
+}
+
+/// All necessary solution data access required to check an individual intent.
+#[derive(Clone, Copy, Debug)]
+pub struct SolutionAccess<'a> {
+    /// The input data for each intent being solved within the solution.
+    ///
+    /// We require *all* intent solution data in order to handle transient
+    /// decision variable access.
+    pub data: &'a [SolutionData],
+    /// Checking is performed for one intent at a time. This index refers to
+    /// the checked intent's associated solution data within `data`.
+    pub index: usize,
+}
+
+/// The pre and post mutation state slot values for the intent being solved.
+#[derive(Clone, Copy, Debug)]
+pub struct StateSlots<'a> {
+    /// Intent state slot values before the solution's mutations are applied.
+    pub pre: &'a StateSlotSlice,
+    /// Intent state slot values after the solution's mutations are applied.
+    pub post: &'a StateSlotSlice,
+}
+
+/// The state slots declared within the intent.
+pub type StateSlotSlice = [Option<Word>];
+
+impl<'a> SolutionAccess<'a> {
+    /// The solution data associated with the intent currently being checked.
+    ///
+    /// **Panics** in the case that `self.index` is out of range of the `self.data` slice.
+    pub fn this_data(&self) -> &SolutionData {
+        self.data
+            .get(self.index)
+            .expect("intent index out of range of solution data")
+    }
+}
+
+impl<'a> StateSlots<'a> {
+    /// Empty state slots.
+    pub const EMPTY: Self = Self {
+        pre: &[],
+        post: &[],
+    };
+}
+
+/// `Access::DecisionVar` implementation.
+pub(crate) fn decision_var(solution: SolutionAccess, stack: &mut Stack) -> OpResult<()> {
+    stack.pop1_push1(|slot| {
+        let ix = usize::try_from(slot).map_err(|_| AccessError::DecisionSlotOutOfBounds)?;
+        let w = resolve_decision_var(solution.data, solution.index, ix)?;
+        Ok(w)
+    })
+}
+
+/// `Access::DecisionVarRange` implementation.
+pub(crate) fn decision_var_range(solution: SolutionAccess, stack: &mut Stack) -> OpResult<()> {
+    let [slot, len] = stack.pop2()?;
+    let range = range_from_start_len(slot, len).ok_or(AccessError::DecisionSlotOutOfBounds)?;
+    for dec_var_ix in range {
+        let w = resolve_decision_var(solution.data, solution.index, dec_var_ix)?;
+        stack.push(w)?;
+    }
+    Ok(())
+}
+
+/// `Access::State` implementation.
+pub(crate) fn state(slots: StateSlots, stack: &mut Stack) -> OpResult<()> {
+    stack.pop2_push1(|slot, delta| {
+        let slot = state_slot(slots, slot, delta)?;
+        let word = slot.ok_or(AccessError::StateSlotWasNone)?;
+        Ok(word)
+    })
+}
+
+/// `Access::StateRange` implementation.
+pub(crate) fn state_range(slots: StateSlots, stack: &mut Stack) -> OpResult<()> {
+    let [slot, len, delta] = stack.pop3()?;
+    let slice = state_slot_range(slots, slot, len, delta)?;
+    for slot in slice {
+        let word = slot.ok_or(AccessError::StateSlotWasNone)?;
+        stack.push(word)?;
+    }
+    Ok(())
+}
+
+/// `Access::StateIsSome` implementation.
+pub(crate) fn state_is_some(slots: StateSlots, stack: &mut Stack) -> OpResult<()> {
+    stack.pop2_push1(|slot, delta| {
+        let slot = state_slot(slots, slot, delta)?;
+        let is_some = Word::from(slot.is_some());
+        Ok(is_some)
+    })
+}
+
+/// `Access::StateIsSomeRange` implementation.
+pub(crate) fn state_is_some_range(slots: StateSlots, stack: &mut Stack) -> OpResult<()> {
+    let [slot, len, delta] = stack.pop3()?;
+    let slice = state_slot_range(slots, slot, len, delta)?;
+    for slot in slice {
+        let is_some = Word::from(slot.is_some());
+        stack.push(is_some)?;
+    }
+    Ok(())
+}
+
+/// `Access::ThisAddress` implementation.
+pub(crate) fn this_address(data: &SolutionData, stack: &mut Stack) -> OpResult<()> {
+    let words = word_4_from_u8_32(data.intent_to_solve.intent.0);
+    stack.extend(words)?;
+    Ok(())
+}
+
+/// `Access::ThisSetAddress` implementation.
+pub(crate) fn this_set_address(data: &SolutionData, stack: &mut Stack) -> OpResult<()> {
+    let words = word_4_from_u8_32(data.intent_to_solve.set.0);
+    stack.extend(words)?;
+    Ok(())
+}
+
+/// Resolve the decision variable by traversing any necessary transient data.
+///
+/// Errors if the solution data or decision var indices are out of bounds
+/// (whether provided directly or via a transient decision var) or if a cycle
+/// occurs between transient decision variables.
+fn resolve_decision_var(
+    data: &[SolutionData],
+    mut data_ix: usize,
+    mut var_ix: usize,
+) -> Result<Word, AccessError> {
+    // Track visited vars `(data_ix, var_ix)` to ensure we do not enter a cycle.
+    let mut visited = std::collections::HashSet::new();
+    loop {
+        let solution_data = data
+            .get(data_ix)
+            .ok_or(AccessError::SolutionDataOutOfBounds)?;
+        let dec_var = solution_data
+            .decision_variables
+            .get(var_ix)
+            .ok_or(AccessError::DecisionSlotOutOfBounds)?;
+        match *dec_var {
+            DecisionVariable::Inline(w) => return Ok(w),
+            DecisionVariable::Transient(ref transient) => {
+                // We're traversing transient data, so make sure we track vars already visited.
+                if !visited.insert((data_ix, var_ix)) {
+                    return Err(AccessError::TransientDecisionVariableCycle);
+                }
+                data_ix = transient.solution_data_index.into();
+                var_ix = transient.variable_index.into();
+            }
+        }
+    }
+}
+
+fn state_slot(slots: StateSlots, slot: Word, delta: Word) -> OpResult<&Option<Word>> {
+    let delta = bool_from_word(delta).ok_or(AccessError::InvalidStateSlotDelta(delta))?;
+    let slots = state_slots_from_delta(slots, delta);
+    let ix = usize::try_from(slot).map_err(|_| AccessError::StateSlotOutOfBounds)?;
+    let slot = slots.get(ix).ok_or(AccessError::StateSlotOutOfBounds)?;
+    Ok(slot)
+}
+
+fn state_slot_range(
+    slots: StateSlots,
+    slot: Word,
+    len: Word,
+    delta: Word,
+) -> OpResult<&StateSlotSlice> {
+    let delta = bool_from_word(delta).ok_or(AccessError::InvalidStateSlotDelta(slot))?;
+    let slots = state_slots_from_delta(slots, delta);
+    let range = range_from_start_len(slot, len).ok_or(AccessError::StateSlotOutOfBounds)?;
+    let subslice = slots
+        .get(range)
+        .ok_or(AccessError::DecisionSlotOutOfBounds)?;
+    Ok(subslice)
+}
+
+fn range_from_start_len(start: Word, len: Word) -> Option<std::ops::Range<usize>> {
+    let start = usize::try_from(start).ok()?;
+    let len = usize::try_from(len).ok()?;
+    let end = start.checked_add(len)?;
+    Some(start..end)
+}
+
+fn state_slots_from_delta(slots: StateSlots, delta: bool) -> &StateSlotSlice {
+    if delta {
+        slots.post
+    } else {
+        slots.pre
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        asm,
+        error::{AccessError, ConstraintError, OpError},
+        eval_ops, exec_ops,
+        test_util::*,
+    };
+    use essential_types::solution::DecisionVariableIndex;
+
+    #[test]
+    fn decision_var_inline() {
+        let access = Access {
+            solution: SolutionAccess {
+                data: &[SolutionData {
+                    intent_to_solve: TEST_INTENT_ADDR,
+                    decision_variables: vec![DecisionVariable::Inline(42)],
+                }],
+                index: 0,
+            },
+            state_slots: StateSlots::EMPTY,
+        };
+        let ops = &[
+            asm::Stack::Push(0).into(), // Slot index.
+            asm::Access::DecisionVar.into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), access).unwrap();
+        assert_eq!(&stack[..], &[42]);
+    }
+
+    #[test]
+    fn decision_var_transient() {
+        // Test resolution of transient decision vars over the following path:
+        // - Solution 1, Var 2 (start)
+        // - Solution 0, Var 3
+        // - Solution 2, Var 1
+        let access = Access {
+            solution: SolutionAccess {
+                data: &[
+                    SolutionData {
+                        intent_to_solve: TEST_INTENT_ADDR,
+                        decision_variables: vec![
+                            DecisionVariable::Inline(0),
+                            DecisionVariable::Inline(1),
+                            DecisionVariable::Inline(2),
+                            DecisionVariable::Transient(DecisionVariableIndex {
+                                solution_data_index: 2,
+                                variable_index: 1,
+                            }),
+                        ],
+                    },
+                    SolutionData {
+                        intent_to_solve: TEST_INTENT_ADDR,
+                        decision_variables: vec![
+                            DecisionVariable::Inline(0),
+                            DecisionVariable::Inline(1),
+                            DecisionVariable::Transient(DecisionVariableIndex {
+                                solution_data_index: 0,
+                                variable_index: 3,
+                            }),
+                            DecisionVariable::Inline(3),
+                        ],
+                    },
+                    SolutionData {
+                        intent_to_solve: TEST_INTENT_ADDR,
+                        decision_variables: vec![
+                            DecisionVariable::Inline(0),
+                            DecisionVariable::Inline(42),
+                        ],
+                    },
+                ],
+                // Solution data for intent being solved is at index 1.
+                index: 1,
+            },
+            state_slots: StateSlots::EMPTY,
+        };
+        let ops = &[
+            asm::Stack::Push(2).into(), // Slot index.
+            asm::Access::DecisionVar.into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), access).unwrap();
+        assert_eq!(&stack[..], &[42]);
+    }
+
+    #[test]
+    fn decision_var_range() {
+        let access = Access {
+            solution: SolutionAccess {
+                data: &[SolutionData {
+                    intent_to_solve: TEST_INTENT_ADDR,
+                    decision_variables: vec![
+                        DecisionVariable::Inline(7),
+                        DecisionVariable::Inline(8),
+                        DecisionVariable::Inline(9),
+                    ],
+                }],
+                index: 0,
+            },
+            state_slots: StateSlots::EMPTY,
+        };
+        let ops = &[
+            asm::Stack::Push(0).into(), // Slot index.
+            asm::Stack::Push(3).into(), // Range length.
+            asm::Access::DecisionVarRange.into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), access).unwrap();
+        assert_eq!(&stack[..], &[7, 8, 9]);
+    }
+
+    #[test]
+    fn decision_var_range_transient() {
+        let access = Access {
+            solution: SolutionAccess {
+                data: &[
+                    SolutionData {
+                        intent_to_solve: TEST_INTENT_ADDR,
+                        decision_variables: vec![
+                            DecisionVariable::Transient(DecisionVariableIndex {
+                                solution_data_index: 1,
+                                variable_index: 2,
+                            }),
+                            DecisionVariable::Transient(DecisionVariableIndex {
+                                solution_data_index: 1,
+                                variable_index: 1,
+                            }),
+                            DecisionVariable::Transient(DecisionVariableIndex {
+                                solution_data_index: 1,
+                                variable_index: 0,
+                            }),
+                        ],
+                    },
+                    SolutionData {
+                        intent_to_solve: TEST_INTENT_ADDR,
+                        decision_variables: vec![
+                            DecisionVariable::Inline(7),
+                            DecisionVariable::Inline(8),
+                            DecisionVariable::Inline(9),
+                        ],
+                    },
+                ],
+                index: 0,
+            },
+            state_slots: StateSlots::EMPTY,
+        };
+        let ops = &[
+            asm::Stack::Push(0).into(), // Slot index.
+            asm::Stack::Push(3).into(), // Range length.
+            asm::Access::DecisionVarRange.into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), access).unwrap();
+        assert_eq!(&stack[..], &[9, 8, 7]);
+    }
+
+    #[test]
+    fn decision_var_transient_cycle() {
+        let access = Access {
+            solution: SolutionAccess {
+                data: &[
+                    SolutionData {
+                        intent_to_solve: TEST_INTENT_ADDR,
+                        decision_variables: vec![DecisionVariable::Transient(
+                            DecisionVariableIndex {
+                                solution_data_index: 1,
+                                variable_index: 0,
+                            },
+                        )],
+                    },
+                    SolutionData {
+                        intent_to_solve: TEST_INTENT_ADDR,
+                        decision_variables: vec![DecisionVariable::Transient(
+                            DecisionVariableIndex {
+                                solution_data_index: 0,
+                                variable_index: 0,
+                            },
+                        )],
+                    },
+                ],
+                index: 0,
+            },
+            state_slots: StateSlots::EMPTY,
+        };
+        let ops = &[
+            asm::Stack::Push(0).into(), // Slot index.
+            asm::Access::DecisionVar.into(),
+        ];
+        let res = exec_ops(ops.iter().copied(), access);
+        match res {
+            Err(ConstraintError::Op(
+                _,
+                OpError::Access(AccessError::TransientDecisionVariableCycle),
+            )) => (),
+            _ => panic!("expected transient decision variable cycle error, got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn decision_var_slot_oob() {
+        let access = Access {
+            solution: SolutionAccess {
+                data: &[SolutionData {
+                    intent_to_solve: TEST_INTENT_ADDR,
+                    decision_variables: vec![DecisionVariable::Inline(42)],
+                }],
+                index: 0,
+            },
+            state_slots: StateSlots::EMPTY,
+        };
+        let ops = &[
+            asm::Stack::Push(1).into(), // Slot index.
+            asm::Access::DecisionVar.into(),
+        ];
+        let res = exec_ops(ops.iter().copied(), access);
+        match res {
+            Err(ConstraintError::Op(_, OpError::Access(AccessError::DecisionSlotOutOfBounds))) => {
+                ()
+            }
+            _ => panic!("expected decision variable slot out-of-bounds error, got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn state_pre_mutation() {
+        let access = Access {
+            solution: TEST_SOLUTION_ACCESS,
+            state_slots: StateSlots {
+                pre: &[Some(0), Some(42)],
+                post: &[Some(0), Some(0)],
+            },
+        };
+        let ops = &[
+            asm::Stack::Push(1).into(), // Slot index.
+            asm::Stack::Push(0).into(), // Delta (0 for pre-mutation state).
+            asm::Access::State.into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), access).unwrap();
+        assert_eq!(&stack[..], &[42]);
+    }
+
+    #[test]
+    fn state_post_mutation() {
+        let access = Access {
+            solution: TEST_SOLUTION_ACCESS,
+            state_slots: StateSlots {
+                pre: &[Some(0), Some(0)],
+                post: &[Some(42), Some(0)],
+            },
+        };
+        let ops = &[
+            asm::Stack::Push(0).into(), // Slot index.
+            asm::Stack::Push(1).into(), // Delta (1 for post-mutation state).
+            asm::Access::State.into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), access).unwrap();
+        assert_eq!(&stack[..], &[42]);
+    }
+
+    #[test]
+    fn state_pre_mutation_oob() {
+        let access = Access {
+            solution: TEST_SOLUTION_ACCESS,
+            state_slots: StateSlots {
+                pre: &[Some(0), Some(42)],
+                post: &[Some(0), Some(0)],
+            },
+        };
+        let ops = &[
+            asm::Stack::Push(2).into(), // Slot index (out-of-bounds).
+            asm::Stack::Push(0).into(), // Delta (0 for pre-mutation state).
+            asm::Access::State.into(),
+        ];
+        let res = exec_ops(ops.iter().copied(), access);
+        match res {
+            Err(ConstraintError::Op(_, OpError::Access(AccessError::StateSlotOutOfBounds))) => (),
+            _ => panic!("expected state slot out-of-bounds error, got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_state_slot_delta() {
+        let access = Access {
+            solution: TEST_SOLUTION_ACCESS,
+            state_slots: StateSlots {
+                pre: &[Some(0), Some(42)],
+                post: &[Some(0), Some(0)],
+            },
+        };
+        let ops = &[
+            asm::Stack::Push(1).into(), // Slot index.
+            asm::Stack::Push(2).into(), // Delta (invalid).
+            asm::Access::State.into(),
+        ];
+        let res = exec_ops(ops.iter().copied(), access);
+        match res {
+            Err(ConstraintError::Op(_, OpError::Access(AccessError::InvalidStateSlotDelta(2)))) => {
+                ()
+            }
+            _ => panic!("expected invalid state slot delta error, got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn state_slot_was_none() {
+        let access = Access {
+            solution: TEST_SOLUTION_ACCESS,
+            state_slots: StateSlots {
+                pre: &[None],
+                post: &[None],
+            },
+        };
+        let ops = &[
+            asm::Stack::Push(0).into(), // Slot index.
+            asm::Stack::Push(0).into(), // Delta.
+            asm::Access::State.into(),
+        ];
+        let res = exec_ops(ops.iter().copied(), access);
+        match res {
+            Err(ConstraintError::Op(_, OpError::Access(AccessError::StateSlotWasNone))) => (),
+            _ => panic!("expected state slot was none error, got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn state_range_pre_mutation() {
+        let access = Access {
+            solution: TEST_SOLUTION_ACCESS,
+            state_slots: StateSlots {
+                pre: &[Some(10), Some(20), Some(30)],
+                post: &[Some(0), Some(0), Some(0)],
+            },
+        };
+        let ops = &[
+            asm::Stack::Push(0).into(), // Slot index.
+            asm::Stack::Push(3).into(), // Range length.
+            asm::Stack::Push(0).into(), // Delta (0 for pre-mutation state).
+            asm::Access::StateRange.into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), access).unwrap();
+        assert_eq!(&stack[..], &[10, 20, 30]);
+    }
+
+    #[test]
+    fn state_range_post_mutation() {
+        let access = Access {
+            solution: TEST_SOLUTION_ACCESS,
+            state_slots: StateSlots {
+                pre: &[Some(0), Some(0), Some(0)],
+                post: &[Some(0), Some(40), Some(50)],
+            },
+        };
+        let ops = &[
+            asm::Stack::Push(1).into(), // Slot index.
+            asm::Stack::Push(2).into(), // Range length.
+            asm::Stack::Push(1).into(), // Delta (1 for post-mutation state).
+            asm::Access::StateRange.into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), access).unwrap();
+        assert_eq!(&stack[..], &[40, 50]);
+    }
+
+    #[test]
+    fn state_is_some_pre_mutation_false() {
+        let access = Access {
+            solution: TEST_SOLUTION_ACCESS,
+            state_slots: StateSlots {
+                pre: &[Some(0), None],
+                post: &[Some(0), Some(0)],
+            },
+        };
+        let ops = &[
+            asm::Stack::Push(1).into(), // Slot index.
+            asm::Stack::Push(0).into(), // Delta (0 for pre-mutation state).
+            asm::Access::StateIsSome.into(),
+        ];
+        // Expect false for `None`.
+        assert!(!eval_ops(ops.iter().copied(), access).unwrap());
+    }
+
+    #[test]
+    fn state_is_some_post_mutation_true() {
+        let access = Access {
+            solution: TEST_SOLUTION_ACCESS,
+            state_slots: StateSlots {
+                pre: &[None, None],
+                post: &[Some(42), None],
+            },
+        };
+        let ops = &[
+            asm::Stack::Push(0).into(), // Slot index.
+            asm::Stack::Push(1).into(), // Delta (1 for post-mutation state).
+            asm::Access::StateIsSome.into(),
+        ];
+        // Expect true for `Some(42)`.
+        assert!(eval_ops(ops.iter().copied(), access).unwrap());
+    }
+
+    #[test]
+    fn state_is_some_range_pre_mutation() {
+        let access = Access {
+            solution: TEST_SOLUTION_ACCESS,
+            state_slots: StateSlots {
+                pre: &[Some(10), None, Some(30)],
+                post: &[None, None, None],
+            },
+        };
+        let ops = &[
+            asm::Stack::Push(0).into(), // Slot index.
+            asm::Stack::Push(3).into(), // Range length.
+            asm::Stack::Push(0).into(), // Delta (0 for pre-mutation state).
+            asm::Access::StateIsSomeRange.into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), access).unwrap();
+        // Expect true, false, true for `Some(10), None, Some(30)`.
+        assert_eq!(&stack[..], &[1, 0, 1]);
+    }
+
+    #[test]
+    fn state_is_some_range_post_mutation() {
+        let access = Access {
+            solution: TEST_SOLUTION_ACCESS,
+            state_slots: StateSlots {
+                pre: &[None, None, None],
+                post: &[None, Some(40), None],
+            },
+        };
+        let ops = &[
+            asm::Stack::Push(0).into(), // Slot index.
+            asm::Stack::Push(3).into(), // Range length.
+            asm::Stack::Push(1).into(), // Delta (1 for post-mutation state).
+            asm::Access::StateIsSomeRange.into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), access).unwrap();
+        // Expect false, true, false for `None, Some(40), None`.
+        assert_eq!(&stack[..], &[0, 1, 0]);
+    }
+
+    #[test]
+    fn this_address() {
+        let ops = &[asm::Access::ThisAddress.into()];
+        let stack = exec_ops(ops.iter().copied(), TEST_ACCESS).unwrap();
+        let expected_words = word_4_from_u8_32(TEST_INTENT_ADDR.intent.0);
+        assert_eq!(&stack[..], expected_words);
+    }
+
+    #[test]
+    fn this_set_address() {
+        let ops = &[asm::Access::ThisSetAddress.into()];
+        let stack = exec_ops(ops.iter().copied(), TEST_ACCESS).unwrap();
+        let expected_words = word_4_from_u8_32(TEST_INTENT_ADDR.set.0);
+        assert_eq!(&stack[..], expected_words);
+    }
+}

--- a/crates/constraint-vm/src/alu.rs
+++ b/crates/constraint-vm/src/alu.rs
@@ -1,0 +1,109 @@
+//! ALU operation implementations.
+
+use crate::{asm::Word, error::AluError, OpResult};
+
+pub(crate) fn add(a: Word, b: Word) -> OpResult<Word> {
+    a.checked_add(b).ok_or(AluError::Overflow.into())
+}
+
+pub(crate) fn sub(a: Word, b: Word) -> OpResult<Word> {
+    a.checked_sub(b).ok_or(AluError::Underflow.into())
+}
+
+pub(crate) fn mul(a: Word, b: Word) -> OpResult<Word> {
+    a.checked_mul(b).ok_or(AluError::Overflow.into())
+}
+
+pub(crate) fn div(a: Word, b: Word) -> OpResult<Word> {
+    a.checked_div(b).ok_or(AluError::DivideByZero.into())
+}
+
+pub(crate) fn mod_(a: Word, b: Word) -> OpResult<Word> {
+    a.checked_rem(b).ok_or(AluError::DivideByZero.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        asm::{Alu, Pred, Stack, Word},
+        error::{AluError, ConstraintError, OpError},
+        eval_ops,
+        test_util::*,
+    };
+
+    #[test]
+    fn eval_6_mul_7_eq_42() {
+        let ops = &[
+            Stack::Push(6).into(),
+            Stack::Push(7).into(),
+            Alu::Mul.into(),
+            Stack::Push(42).into(),
+            Pred::Eq.into(),
+        ];
+        eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap();
+    }
+
+    #[test]
+    fn eval_42_div_6_eq_7() {
+        let ops = &[
+            Stack::Push(42).into(),
+            Stack::Push(7).into(),
+            Alu::Div.into(),
+            Stack::Push(6).into(),
+            Pred::Eq.into(),
+        ];
+        eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap();
+    }
+
+    #[test]
+    fn eval_divide_by_zero() {
+        let ops = &[
+            Stack::Push(42).into(),
+            Stack::Push(0).into(),
+            Alu::Div.into(),
+        ];
+        match eval_ops(ops.iter().copied(), TEST_ACCESS) {
+            Err(ConstraintError::Op(_, OpError::Alu(AluError::DivideByZero))) => (),
+            _ => panic!("expected ALU divide-by-zero error"),
+        }
+    }
+
+    #[test]
+    fn eval_add_overflow() {
+        let ops = &[
+            Stack::Push(Word::MAX).into(),
+            Stack::Push(1).into(),
+            Alu::Add.into(),
+        ];
+        match eval_ops(ops.iter().copied(), TEST_ACCESS) {
+            Err(ConstraintError::Op(_, OpError::Alu(AluError::Overflow))) => (),
+            _ => panic!("expected ALU overflow error"),
+        }
+    }
+
+    #[test]
+    fn eval_mul_overflow() {
+        let ops = &[
+            Stack::Push(Word::MAX).into(),
+            Stack::Push(2).into(),
+            Alu::Mul.into(),
+        ];
+        match eval_ops(ops.iter().copied(), TEST_ACCESS) {
+            Err(ConstraintError::Op(_, OpError::Alu(AluError::Overflow))) => (),
+            _ => panic!("expected ALU overflow error"),
+        }
+    }
+
+    #[test]
+    fn eval_sub_underflow() {
+        let ops = &[
+            Stack::Push(Word::MIN).into(),
+            Stack::Push(1).into(),
+            Alu::Sub.into(),
+        ];
+        match eval_ops(ops.iter().copied(), TEST_ACCESS) {
+            Err(ConstraintError::Op(_, OpError::Alu(AluError::Underflow))) => (),
+            _ => panic!("expected ALU underflow error"),
+        }
+    }
+}

--- a/crates/constraint-vm/src/crypto.rs
+++ b/crates/constraint-vm/src/crypto.rs
@@ -1,0 +1,172 @@
+//! Crypto operation implementations.
+
+use crate::{
+    asm::Word,
+    error::{CryptoError, OpError},
+    OpResult, Stack,
+};
+use essential_types::convert::{
+    bytes_from_word, u8_32_from_word_4, u8_64_from_word_8, word_4_from_u8_32,
+};
+
+/// `Crypto::Sha256` implementation.
+pub(crate) fn sha256(stack: &mut Stack) -> OpResult<()> {
+    use sha2::Digest;
+    let data = stack.pop_len_words::<_, Vec<_>, OpError>(|words| {
+        Ok(bytes_from_words(words.iter().copied()).collect())
+    })?;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(&data);
+    let hash_bytes: [u8; 32] = hasher.finalize().into();
+    let hash_words = word_4_from_u8_32(hash_bytes);
+    stack.extend(hash_words)?;
+    Ok(())
+}
+
+/// `Crypto::VerifyEd25519` implementation.
+pub(crate) fn verify_ed25519(stack: &mut Stack) -> OpResult<()> {
+    use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+    let pubkey_words = stack.pop4()?;
+    let signature_words = stack.pop8()?;
+    let data = stack.pop_len_words::<_, Vec<_>, OpError>(|words| {
+        Ok(bytes_from_words(words.iter().copied()).collect())
+    })?;
+    let pubkey_bytes = u8_32_from_word_4(pubkey_words);
+    let pubkey = VerifyingKey::from_bytes(&pubkey_bytes).map_err(CryptoError::Ed25519)?;
+    let signature_bytes = u8_64_from_word_8(signature_words);
+    let signature = Signature::from_bytes(&signature_bytes);
+    let valid = pubkey.verify(&data, &signature).is_ok();
+    let word = Word::from(valid);
+    stack.push(word)?;
+    Ok(())
+}
+
+fn bytes_from_words(words: impl IntoIterator<Item = Word>) -> impl Iterator<Item = u8> {
+    words.into_iter().flat_map(bytes_from_word)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        asm::{Crypto, Op, Stack, Word},
+        crypto::bytes_from_words,
+        error::{ConstraintError, CryptoError, OpError},
+        eval_ops, exec_ops,
+        test_util::*,
+        types::{
+            convert::{bytes_from_word, word_4_from_u8_32, word_8_from_u8_64},
+            Hash,
+        },
+    };
+
+    fn exec_ops_sha256(ops: &[Op]) -> Hash {
+        let stack = exec_ops(ops.iter().copied(), TEST_ACCESS).unwrap();
+        assert_eq!(stack.len(), 4);
+        let bytes: Vec<u8> = stack.iter().copied().flat_map(bytes_from_word).collect();
+        bytes.try_into().unwrap()
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn sha256_1_word() {
+        let ops = &[
+            Stack::Push(0x0000000000000000).into(), // Data
+            Stack::Push(1).into(), // Data Length
+            Crypto::Sha256.into(),
+        ];
+        let hash = exec_ops_sha256(ops);
+        // Value retrieved externally using command:
+        // $ echo "0000000000000000" | xxd -r -p | sha256sum
+        let expected = [
+            0xaf, 0x55, 0x70, 0xf5, 0xa1, 0x81, 0x0b, 0x7a,
+            0xf7, 0x8c, 0xaf, 0x4b, 0xc7, 0x0a, 0x66, 0x0f,
+            0x0d, 0xf5, 0x1e, 0x42, 0xba, 0xf9, 0x1d, 0x4d,
+            0xe5, 0xb2, 0x32, 0x8d, 0xe0, 0xe8, 0x3d, 0xfc,
+        ];
+        assert_eq!(&hash[..], &expected);
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn sha256_3_words() {
+        let ops = &[
+            Stack::Push(0x00000000000000FF).into(), // Data
+            Stack::Push(0x00000000000000FF).into(), // Data
+            Stack::Push(0x00000000000000FF).into(), // Data
+            Stack::Push(3).into(), // Data Length
+            Crypto::Sha256.into(),
+        ];
+        let hash = exec_ops_sha256(ops);
+        // Value retrieved externally using command:
+        // $ echo "00000000000000FF00000000000000FF00000000000000FF" | xxd -r -p | sha256sum
+        let expected = [
+            0x58, 0x2d, 0xc8, 0xbd, 0xf8, 0xed, 0x36, 0x46,
+            0x65, 0xa2, 0xd4, 0x59, 0x13, 0xc4, 0x79, 0x9f,
+            0x38, 0x6e, 0xe0, 0xc2, 0x51, 0x96, 0x80, 0x81,
+            0x00, 0xe2, 0xfc, 0x2d, 0xae, 0x75, 0x00, 0xd6,
+        ];
+        assert_eq!(&hash[..], &expected);
+    }
+
+    // Generate some test operations for a successful ed25519 verification.
+    fn test_ed25519_ops() -> Vec<Op> {
+        use ed25519_dalek::{Signer, SigningKey};
+        use rand::{Rng, SeedableRng};
+
+        // Test data.
+        let data: &[Word] = &[7, 3, 5, 7];
+        let data_bytes: Vec<_> = bytes_from_words(data.iter().copied()).collect();
+
+        // Generate keys.
+        let mut rng = rand::rngs::SmallRng::from_seed([0x00; 32]);
+        let key_bytes = rng.gen();
+        let privkey: SigningKey = SigningKey::from_bytes(&key_bytes);
+        let pubkey = privkey.verifying_key();
+        let pubkey_bytes = pubkey.to_bytes();
+
+        // Sign the data and check it verifies.
+        let signature = privkey.sign(&data_bytes);
+        pubkey.verify_strict(&data_bytes, &signature).unwrap();
+        let signature_bytes = signature.to_bytes();
+
+        // Push the data, length, signature, pubkey and finally the `VerifyEd25519` op.
+        data.iter()
+            .copied()
+            .chain(Some(Word::try_from(data.len()).unwrap()))
+            .chain(word_8_from_u8_64(signature_bytes))
+            .chain(word_4_from_u8_32(pubkey_bytes))
+            .map(Stack::Push)
+            .map(Op::from)
+            .chain(Some(Crypto::VerifyEd25519.into()))
+            .collect()
+    }
+
+    #[test]
+    fn verify_ed25519_true() {
+        let ops = test_ed25519_ops();
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn verify_ed25519_false() {
+        let mut ops = test_ed25519_ops();
+        ops[0] = Stack::Push(0).into(); // Invalidate data.
+        assert!(!eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn ed25519_error() {
+        let mut ops = test_ed25519_ops();
+        // Invalidate pubkey.
+        let key_ix = ops.len() - 5;
+        ops[key_ix] = Stack::Push(1).into();
+        ops[key_ix + 1] = Stack::Push(1).into();
+        ops[key_ix + 2] = Stack::Push(1).into();
+        ops[key_ix + 3] = Stack::Push(1).into();
+        let res = eval_ops(ops.iter().copied(), TEST_ACCESS);
+        match res {
+            Err(ConstraintError::Op(_, OpError::Crypto(CryptoError::Ed25519(_err)))) => (),
+            _ => panic!("expected ed25519 error, got {res:?}"),
+        }
+    }
+}

--- a/crates/constraint-vm/src/error.rs
+++ b/crates/constraint-vm/src/error.rs
@@ -1,0 +1,154 @@
+//! The types of errors that might occur throughout constraint checking.
+
+use crate::{
+    asm::{self, Word},
+    Stack,
+};
+use core::fmt;
+use thiserror::Error;
+
+/// Shorthand for a `Result` where the error type is a `CheckError`.
+pub type CheckResult<T> = Result<T, CheckError>;
+
+/// Intent checking error.
+#[derive(Debug, Error)]
+pub enum CheckError {
+    /// Errors occurred while executing one or more constraints.
+    #[error("errors occurred while executing one or more constraints: {0}")]
+    ConstraintErrors(#[from] ConstraintErrors),
+    /// One or more constraints were unsatisfied.
+    #[error("one or more constraints were unsatisfied: {0}")]
+    ConstraintsUnsatisfied(#[from] ConstraintsUnsatisfied),
+}
+
+/// The index of each failed constraint alongside the error it produced.
+#[derive(Debug, Error)]
+pub struct ConstraintErrors(pub Vec<(usize, ConstraintError)>);
+
+/// The index of each constraint that was not satisfied.
+#[derive(Debug, Error)]
+pub struct ConstraintsUnsatisfied(pub Vec<usize>);
+
+/// Shorthand for a `Result` where the error type is a `ConstraintError`.
+pub type ConstraintResult<T> = Result<T, ConstraintError>;
+
+/// Constraint checking error.
+#[derive(Debug, Error)]
+pub enum ConstraintError {
+    /// Evaluation should have resulted with a `0` (false) or `1` (true) at the
+    /// top of the stack, but did not.
+    #[error(
+        "invalid constraint evaluation result\n  \
+        expected: [0] (false) or [1] (true)\n  \
+        found:    {0:?}"
+    )]
+    InvalidEvaluation(Stack),
+    /// The operation at the specified index failed.
+    #[error("operation at index {0} failed: {1}")]
+    Op(usize, OpError),
+}
+
+/// Shorthand for a `Result` where the error type is an `OpError`.
+pub type OpResult<T> = Result<T, OpError>;
+
+/// An individual operation failed during constraint checking error.
+#[derive(Debug, Error)]
+pub enum OpError {
+    /// An error occurred during an `Access` operation.
+    #[error("access operation error: {0}")]
+    Access(#[from] AccessError),
+    /// An error occurred during an `Alu` operation.
+    #[error("ALU operation error: {0}")]
+    Alu(#[from] AluError),
+    /// An error occurred during a `Crypto` operation.
+    #[error("crypto operation error: {0}")]
+    Crypto(#[from] CryptoError),
+    /// An error occurred during a `Stack` operation.
+    #[error("stack operation error: {0}")]
+    Stack(#[from] StackError),
+    /// An error occurred while parsing an operation from bytes.
+    #[error("bytecode error: {0}")]
+    FromBytes(#[from] asm::FromBytesError),
+}
+
+/// Access operation error.
+#[derive(Debug, Error)]
+pub enum AccessError {
+    /// A decision variable index was out of bounds.
+    #[error("decision variable slot out of bounds")]
+    DecisionSlotOutOfBounds,
+    /// A solution data index provided by a transient decision variable was out of bounds.
+    #[error("solution data index out of bounds")]
+    SolutionDataOutOfBounds,
+    /// A cycle was detected between two or more transient decision variables.
+    #[error("a cycle was detected between transient decision variables")]
+    TransientDecisionVariableCycle,
+    /// A state slot index was out of bounds.
+    #[error("state slot out of bounds")]
+    StateSlotOutOfBounds,
+    /// A state slot delta value was invalid. Must be `0` (pre) or `1` (post).
+    #[error("invalid state slot delta: expected `0` or `1`, found {0}")]
+    InvalidStateSlotDelta(Word),
+    /// Attempted to access a state slot that has no value.
+    #[error("attempted to access a state slot that has no value")]
+    StateSlotWasNone,
+}
+
+/// ALU operation error.
+#[derive(Debug, Error)]
+pub enum AluError {
+    /// An ALU operation overflowed a `Word` value.
+    #[error("word overflow")]
+    Overflow,
+    /// An ALU operation underflowed a `Word` value.
+    #[error("word underflow")]
+    Underflow,
+    /// An ALU operation (either Div or Mod) attempted to divide by zero.
+    #[error("attempted to divide by zero")]
+    DivideByZero,
+}
+
+/// Crypto operation error.
+#[derive(Debug, Error)]
+pub enum CryptoError {
+    /// Failed to verify a ED25519 signature.
+    #[error("failed to verify ed25519 signature: {0}")]
+    Ed25519(#[from] ed25519_dalek::ed25519::Error),
+}
+
+/// Shorthand for a `Result` where the error type is a `StackError`.
+pub type StackResult<T> = Result<T, StackError>;
+
+/// Stack operation error.
+#[derive(Debug, Error)]
+pub enum StackError {
+    /// Attempted to pop a word from an empty stack.
+    #[error("attempted to pop an empty stack")]
+    Empty,
+    /// An index into the stack was out of bounds.
+    #[error("indexed stack out of bounds")]
+    IndexOutOfBounds,
+    /// The stack size exceeded the size limit.
+    #[error("the {}-word stack size limit was exceeded", crate::Stack::SIZE_LIMIT)]
+    Overflow,
+}
+
+impl fmt::Display for ConstraintErrors {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("the constraints at the following indices failed: \n")?;
+        for (ix, err) in &self.0 {
+            f.write_str(&format!("  {ix}: {err}\n"))?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for ConstraintsUnsatisfied {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("the constraints at the following indices returned false: \n")?;
+        for ix in &self.0 {
+            f.write_str(&format!("  {ix}\n"))?;
+        }
+        Ok(())
+    }
+}

--- a/crates/constraint-vm/src/lib.rs
+++ b/crates/constraint-vm/src/lib.rs
@@ -1,0 +1,451 @@
+//! The essential constraint checking implementation.
+//!
+//! ## Checking Intents
+//!
+//! The primary entrypoint for this crate is the [`check_intent`] function
+//! which allows for checking a set of constraints associated with a single
+//! intent against some provided solution data and state slot mutations in
+//! parallel.
+//!
+//! ## Checking Individual Constraints
+//!
+//! Functions are also exposed for checking constraints individually.
+//!
+//! - The [`exec_bytecode`] and [`exec_ops`] functions allow for executing the
+//!   constraint and returning the resulting `Stack`.
+//! - The [`eval_bytecode`] and [`eval_ops`] functions are similar to their
+//!   `exec_*` counterparts, but expect the top of the `Stack` to contain a
+//!   single boolean value indicating whether the constraint was satisfied (`0`
+//!   for `false`, `1` for `true`) and returns this value.
+//!
+//! ## Performing a Single Operation
+//!
+//! The [`step_op`] function (and related `step_op_*` functions) are exposed to
+//! allow for applying a single operation to the given stack. This can be useful
+//! in the case of integrating constraint operations in a downstream VM (e.g.
+//! the essential state read VM).
+//!
+//! ## Understanding the Assembly
+//!
+//! The `essential-constraint-asm` crate is re-exported as the [`asm`] module.
+//! See [this module's documentation][asm] for information about the expected
+//! behaviour of individual operations.
+#![deny(missing_docs, unsafe_code)]
+
+pub use access::{Access, SolutionAccess, StateSlotSlice, StateSlots};
+#[doc(inline)]
+pub use error::{CheckResult, ConstraintResult, OpResult, StackResult};
+use error::{ConstraintError, ConstraintErrors, ConstraintsUnsatisfied};
+#[doc(inline)]
+pub use essential_constraint_asm as asm;
+use essential_constraint_asm::Op;
+pub use essential_types as types;
+use essential_types::{convert::bool_from_word, ConstraintBytecode};
+#[doc(inline)]
+pub use stack::Stack;
+
+mod access;
+mod alu;
+mod crypto;
+pub mod error;
+mod stack;
+
+/// Check whether the constraints of a single intent are met for the given
+/// solution data and state slot mutations. All constraints are checked in
+/// parallel.
+///
+/// In the case that one or more constraints fail or are unsatisfied, the
+/// whole set of failed/unsatisfied constraint indices are returned within the
+/// `CheckError` type.
+///
+/// The intent is considered to be satisfied if this function returns `Ok(())`.
+pub fn check_intent(intent: &[ConstraintBytecode], access: Access) -> CheckResult<()> {
+    use rayon::{iter::Either, prelude::*};
+    let (failed, unsatisfied): (Vec<_>, Vec<_>) = intent
+        .par_iter()
+        .map(|bytecode| eval_bytecode(bytecode.iter().copied(), access))
+        .enumerate()
+        .filter_map(|(i, constraint_res)| match constraint_res {
+            Err(err) => Some(Either::Left((i, err))),
+            Ok(b) if !b => Some(Either::Right(i)),
+            _ => None,
+        })
+        .partition_map(|either| either);
+    if !failed.is_empty() {
+        return Err(ConstraintErrors(failed).into());
+    }
+    if !unsatisfied.is_empty() {
+        return Err(ConstraintsUnsatisfied(unsatisfied).into());
+    }
+    Ok(())
+}
+
+/// Evaluate the bytecode of a single constraint and return its boolean result.
+///
+/// This is the same as `exec_bytecode`, but retrieves the boolean result from the resulting stack.
+pub fn eval_bytecode(
+    bytes: impl IntoIterator<Item = u8>,
+    access: Access,
+) -> ConstraintResult<bool> {
+    let stack = exec_bytecode(bytes, access)?;
+    let word = match stack.last() {
+        Some(&w) => w,
+        None => return Err(ConstraintError::InvalidEvaluation(stack)),
+    };
+    bool_from_word(word).ok_or_else(|| ConstraintError::InvalidEvaluation(stack))
+}
+
+/// Evaluate the operations of a single constraint and return its boolean result.
+///
+/// This is the same as `exec_ops`, but retrieves the boolean result from the resulting stack.
+pub fn eval_ops(ops: impl IntoIterator<Item = Op>, access: Access) -> ConstraintResult<bool> {
+    let stack = exec_ops(ops, access)?;
+    let word = match stack.last() {
+        Some(&w) => w,
+        None => return Err(ConstraintError::InvalidEvaluation(stack)),
+    };
+    bool_from_word(word).ok_or_else(|| ConstraintError::InvalidEvaluation(stack))
+}
+
+/// Execute the bytecode of a constraint and return the resulting stack.
+pub fn exec_bytecode(
+    bytes: impl IntoIterator<Item = u8>,
+    access: Access,
+) -> ConstraintResult<Stack> {
+    let mut stack = Stack::default();
+    for (ix, res) in asm::from_bytes(bytes.into_iter()).enumerate() {
+        let op = res.map_err(|err| ConstraintError::Op(ix, err.into()))?;
+        step_op(access, op, &mut stack).map_err(|err| ConstraintError::Op(ix, err))?;
+    }
+    Ok(stack)
+}
+
+/// Execute the operations of a constraint and return the resulting stack.
+pub fn exec_ops(ops: impl IntoIterator<Item = Op>, access: Access) -> ConstraintResult<Stack> {
+    let mut stack = Stack::default();
+    for (ix, op) in ops.into_iter().enumerate() {
+        step_op(access, op, &mut stack).map_err(|err| ConstraintError::Op(ix, err))?;
+    }
+    Ok(stack)
+}
+
+/// Step forward constraint checking by the given operation.
+pub fn step_op(access: Access, op: Op, stack: &mut Stack) -> OpResult<()> {
+    match op {
+        Op::Access(op) => step_op_access(access, op, stack),
+        Op::Alu(op) => step_op_alu(op, stack),
+        Op::Crypto(op) => step_op_crypto(op, stack),
+        Op::Pred(op) => step_op_pred(op, stack),
+        Op::Stack(op) => step_op_stack(op, stack),
+    }
+}
+
+/// Step forward constraint checking by the given access operation.
+pub fn step_op_access(access: Access, op: asm::Access, stack: &mut Stack) -> OpResult<()> {
+    match op {
+        asm::Access::DecisionVar => access::decision_var(access.solution, stack),
+        asm::Access::DecisionVarRange => access::decision_var_range(access.solution, stack),
+        asm::Access::MutKeysLen => todo!(),
+        asm::Access::State => access::state(access.state_slots, stack),
+        asm::Access::StateRange => access::state_range(access.state_slots, stack),
+        asm::Access::StateIsSome => access::state_is_some(access.state_slots, stack),
+        asm::Access::StateIsSomeRange => access::state_is_some_range(access.state_slots, stack),
+        asm::Access::ThisAddress => access::this_address(access.solution.this_data(), stack),
+        asm::Access::ThisSetAddress => access::this_set_address(access.solution.this_data(), stack),
+    }
+}
+
+/// Step forward constraint checking by the given ALU operation.
+pub fn step_op_alu(op: asm::Alu, stack: &mut Stack) -> OpResult<()> {
+    match op {
+        asm::Alu::Add => stack.pop2_push1(alu::add),
+        asm::Alu::Sub => stack.pop2_push1(alu::sub),
+        asm::Alu::Mul => stack.pop2_push1(alu::mul),
+        asm::Alu::Div => stack.pop2_push1(alu::div),
+        asm::Alu::Mod => stack.pop2_push1(alu::mod_),
+    }
+}
+
+/// Step forward constraint checking by the given crypto operation.
+pub fn step_op_crypto(op: asm::Crypto, stack: &mut Stack) -> OpResult<()> {
+    match op {
+        asm::Crypto::Sha256 => crypto::sha256(stack),
+        asm::Crypto::VerifyEd25519 => crypto::verify_ed25519(stack),
+    }
+}
+
+/// Step forward constraint checking by the given predicate operation.
+pub fn step_op_pred(op: asm::Pred, stack: &mut Stack) -> OpResult<()> {
+    match op {
+        asm::Pred::Eq => stack.pop2_push1(|a, b| Ok((a == b).into())),
+        asm::Pred::Eq4 => stack.pop8_push1(|ws| Ok((ws[0..4] == ws[4..8]).into())),
+        asm::Pred::Gt => stack.pop2_push1(|a, b| Ok((a > b).into())),
+        asm::Pred::Lt => stack.pop2_push1(|a, b| Ok((a < b).into())),
+        asm::Pred::Gte => stack.pop2_push1(|a, b| Ok((a >= b).into())),
+        asm::Pred::Lte => stack.pop2_push1(|a, b| Ok((a <= b).into())),
+        asm::Pred::And => stack.pop2_push1(|a, b| Ok((a != 0 && b != 0).into())),
+        asm::Pred::Or => stack.pop2_push1(|a, b| Ok((a != 0 || b != 0).into())),
+        asm::Pred::Not => stack.pop1_push1(|a| Ok((a == 0).into())),
+    }
+}
+
+/// Step forward constraint checking by the given stack operation.
+pub fn step_op_stack(op: asm::Stack, stack: &mut Stack) -> OpResult<()> {
+    match op {
+        asm::Stack::Dup => stack.pop1_push2(|w| Ok([w, w])),
+        asm::Stack::DupFrom => stack.dup_from().map_err(From::from),
+        asm::Stack::Push(word) => stack.push(word).map_err(From::from),
+        asm::Stack::Pop => stack.pop().map(|_| ()).map_err(From::from),
+        asm::Stack::Swap => stack.pop2_push2(|a, b| Ok([b, a])),
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_util {
+    use crate::{
+        types::{solution::SolutionData, ContentAddress, IntentAddress},
+        *,
+    };
+
+    pub(crate) const TEST_SET_CA: ContentAddress = ContentAddress([0xFF; 32]);
+    pub(crate) const TEST_INTENT_CA: ContentAddress = ContentAddress([0xAA; 32]);
+    pub(crate) const TEST_INTENT_ADDR: IntentAddress = IntentAddress {
+        set: TEST_SET_CA,
+        intent: TEST_INTENT_CA,
+    };
+    pub(crate) const TEST_SOLUTION_DATA: SolutionData = SolutionData {
+        intent_to_solve: TEST_INTENT_ADDR,
+        decision_variables: vec![],
+    };
+    pub(crate) const TEST_SOLUTION_ACCESS: SolutionAccess = SolutionAccess {
+        data: &[TEST_SOLUTION_DATA],
+        index: 0,
+    };
+    pub(crate) const TEST_ACCESS: Access = Access {
+        solution: TEST_SOLUTION_ACCESS,
+        state_slots: StateSlots::EMPTY,
+    };
+}
+
+#[cfg(test)]
+mod pred_tests {
+    use crate::{
+        asm::{Pred, Stack},
+        test_util::*,
+        *,
+    };
+
+    #[test]
+    fn pred_eq_false() {
+        let ops = &[
+            Stack::Push(6).into(),
+            Stack::Push(7).into(),
+            Pred::Eq.into(),
+        ];
+        assert!(!eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_eq_true() {
+        let ops = &[
+            Stack::Push(42).into(),
+            Stack::Push(42).into(),
+            Pred::Eq.into(),
+        ];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_eq4_false() {
+        let ops = &[
+            Stack::Push(1).into(),
+            Stack::Push(2).into(),
+            Stack::Push(3).into(),
+            Stack::Push(4).into(),
+            Stack::Push(0).into(),
+            Stack::Push(0).into(),
+            Stack::Push(0).into(),
+            Stack::Push(0).into(),
+            Pred::Eq4.into(),
+        ];
+        assert!(!eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_eq4_true() {
+        let ops = &[
+            Stack::Push(1).into(),
+            Stack::Push(2).into(),
+            Stack::Push(3).into(),
+            Stack::Push(4).into(),
+            Stack::Push(1).into(),
+            Stack::Push(2).into(),
+            Stack::Push(3).into(),
+            Stack::Push(4).into(),
+            Pred::Eq4.into(),
+        ];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_gt_false() {
+        let ops = &[
+            Stack::Push(7).into(),
+            Stack::Push(7).into(),
+            Pred::Gt.into(),
+        ];
+        assert!(!eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_gt_true() {
+        let ops = &[
+            Stack::Push(7).into(),
+            Stack::Push(6).into(),
+            Pred::Gt.into(),
+        ];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_lt_false() {
+        let ops = &[
+            Stack::Push(7).into(),
+            Stack::Push(7).into(),
+            Pred::Lt.into(),
+        ];
+        assert!(!eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_lt_true() {
+        let ops = &[
+            Stack::Push(6).into(),
+            Stack::Push(7).into(),
+            Pred::Lt.into(),
+        ];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_gte_false() {
+        let ops = &[
+            Stack::Push(6).into(),
+            Stack::Push(7).into(),
+            Pred::Gte.into(),
+        ];
+        assert!(!eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_gte_true() {
+        let ops = &[
+            Stack::Push(7).into(),
+            Stack::Push(7).into(),
+            Pred::Gte.into(),
+        ];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+        let ops = &[
+            Stack::Push(8).into(),
+            Stack::Push(7).into(),
+            Pred::Gte.into(),
+        ];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_lte_false() {
+        let ops = &[
+            Stack::Push(7).into(),
+            Stack::Push(6).into(),
+            Pred::Lte.into(),
+        ];
+        assert!(!eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_lte_true() {
+        let ops = &[
+            Stack::Push(7).into(),
+            Stack::Push(7).into(),
+            Pred::Lte.into(),
+        ];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+        let ops = &[
+            Stack::Push(7).into(),
+            Stack::Push(8).into(),
+            Pred::Lte.into(),
+        ];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_and_true() {
+        let ops = &[
+            Stack::Push(42).into(),
+            Stack::Push(42).into(),
+            Pred::And.into(),
+        ];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_and_false() {
+        let ops = &[
+            Stack::Push(42).into(),
+            Stack::Push(0).into(),
+            Pred::And.into(),
+        ];
+        assert!(!eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+        let ops = &[
+            Stack::Push(0).into(),
+            Stack::Push(0).into(),
+            Pred::And.into(),
+        ];
+        assert!(!eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_or_true() {
+        let ops = &[
+            Stack::Push(42).into(),
+            Stack::Push(42).into(),
+            Pred::Or.into(),
+        ];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+        let ops = &[
+            Stack::Push(0).into(),
+            Stack::Push(42).into(),
+            Pred::Or.into(),
+        ];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+        let ops = &[
+            Stack::Push(42).into(),
+            Stack::Push(0).into(),
+            Pred::Or.into(),
+        ];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_or_false() {
+        let ops = &[
+            Stack::Push(0).into(),
+            Stack::Push(0).into(),
+            Pred::Or.into(),
+        ];
+        assert!(!eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_not_true() {
+        let ops = &[Stack::Push(0).into(), Pred::Not.into()];
+        assert!(eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+
+    #[test]
+    fn pred_not_false() {
+        let ops = &[Stack::Push(42).into(), Pred::Not.into()];
+        assert!(!eval_ops(ops.iter().copied(), TEST_ACCESS).unwrap());
+    }
+}

--- a/crates/constraint-vm/src/stack.rs
+++ b/crates/constraint-vm/src/stack.rs
@@ -1,0 +1,281 @@
+//! Stack operation and related stack manipulation implementations.
+
+use crate::{asm::Word, error::StackError, StackResult};
+
+/// The VM's `Stack`, i.e. a `Vec` of `Word`s updated during each step of execution.
+///
+/// A light wrapper around `Vec<Word>` providing helper methods specific to
+/// essential VM execution.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct Stack(Vec<Word>);
+
+impl Stack {
+    /// Limit the stack size to 32KB to avoid memory bloat during parallel constraint checking.
+    pub const SIZE_LIMIT: usize = 4096;
+
+    /// Push a word to the stack.
+    ///
+    /// Errors in the case that pushing an element would cause the stack to overflow.
+    pub fn push(&mut self, word: Word) -> StackResult<()> {
+        if self.len() >= Self::SIZE_LIMIT {
+            return Err(StackError::Overflow);
+        }
+        self.0.push(word);
+        Ok(())
+    }
+
+    /// Extend the stack by with the given iterator yielding words.
+    ///
+    /// Errors in the case that pushing an element would cause the stack to overflow.
+    pub fn extend(&mut self, words: impl IntoIterator<Item = Word>) -> StackResult<()> {
+        for word in words {
+            self.push(word)?;
+        }
+        Ok(())
+    }
+
+    /// The DupFrom op implementation.
+    pub(crate) fn dup_from(&mut self) -> StackResult<()> {
+        let rev_ix_w = self.pop()?;
+        let rev_ix = usize::try_from(rev_ix_w).map_err(|_| StackError::IndexOutOfBounds)?;
+        let ix = self
+            .len()
+            .checked_sub(rev_ix)
+            .and_then(|i| i.checked_sub(1))
+            .ok_or(StackError::IndexOutOfBounds)?;
+        let w = *self.get(ix).ok_or(StackError::IndexOutOfBounds)?;
+        self.push(w)?;
+        Ok(())
+    }
+
+    /// A wrapper around `Vec::pop`, producing an error in the case that the stack is empty.
+    pub fn pop(&mut self) -> StackResult<Word> {
+        self.0.pop().ok_or(StackError::Empty)
+    }
+
+    /// Pop the top 2 values from the stack.
+    ///
+    /// The last values popped appear first in the returned fixed-size array.
+    pub fn pop2(&mut self) -> StackResult<[Word; 2]> {
+        let w1 = self.pop()?;
+        let w0 = self.pop()?;
+        Ok([w0, w1])
+    }
+
+    /// Pop the top 3 values from the stack.
+    ///
+    /// The last values popped appear first in the returned fixed-size array.
+    pub fn pop3(&mut self) -> StackResult<[Word; 3]> {
+        let w2 = self.pop()?;
+        let [w0, w1] = self.pop2()?;
+        Ok([w0, w1, w2])
+    }
+
+    /// Pop the top 4 values from the stack.
+    ///
+    /// The last values popped appear first in the returned fixed-size array.
+    pub fn pop4(&mut self) -> StackResult<[Word; 4]> {
+        let w3 = self.pop()?;
+        let [w0, w1, w2] = self.pop3()?;
+        Ok([w0, w1, w2, w3])
+    }
+
+    /// Pop the top 8 values from the stack.
+    ///
+    /// The last values popped appear first in the returned fixed-size array.
+    pub fn pop8(&mut self) -> StackResult<[Word; 8]> {
+        let [w4, w5, w6, w7] = self.pop4()?;
+        let [w0, w1, w2, w3] = self.pop4()?;
+        Ok([w0, w1, w2, w3, w4, w5, w6, w7])
+    }
+
+    /// Pop 1 word from the stack, apply the given function and push the returned word.
+    pub fn pop1_push1<F, E>(&mut self, f: F) -> Result<(), E>
+    where
+        F: FnOnce(Word) -> Result<Word, E>,
+        E: From<StackError>,
+    {
+        let w = self.pop()?;
+        let x = f(w)?;
+        self.push(x)?;
+        Ok(())
+    }
+
+    /// Pop 2 words from the stack, apply the given function and push the returned word.
+    pub fn pop2_push1<F, E>(&mut self, f: F) -> Result<(), E>
+    where
+        F: FnOnce(Word, Word) -> Result<Word, E>,
+        E: From<StackError>,
+    {
+        let [w0, w1] = self.pop2()?;
+        let x = f(w0, w1)?;
+        self.push(x)?;
+        Ok(())
+    }
+
+    /// Pop 8 words from the stack, apply the given function and push the returned word.
+    pub fn pop8_push1<F, E>(&mut self, f: F) -> Result<(), E>
+    where
+        F: FnOnce([Word; 8]) -> Result<Word, E>,
+        E: From<StackError>,
+    {
+        let ws = self.pop8()?;
+        let x = f(ws)?;
+        self.push(x)?;
+        Ok(())
+    }
+
+    /// Pop 1 word from the stack, apply the given function and push the 2 returned words.
+    pub fn pop1_push2<F, E>(&mut self, f: F) -> Result<(), E>
+    where
+        F: FnOnce(Word) -> Result<[Word; 2], E>,
+        E: From<StackError>,
+    {
+        let w = self.pop()?;
+        let xs = f(w)?;
+        self.extend(xs)?;
+        Ok(())
+    }
+
+    /// Pop 2 words from the stack, apply the given function and push the 2 returned words.
+    pub fn pop2_push2<F, E>(&mut self, f: F) -> Result<(), E>
+    where
+        F: FnOnce(Word, Word) -> Result<[Word; 2], E>,
+        E: From<StackError>,
+    {
+        let [w0, w1] = self.pop2()?;
+        let xs = f(w0, w1)?;
+        self.extend(xs)?;
+        Ok(())
+    }
+
+    /// Pop 2 words from the stack, apply the given function and push the 4 returned words.
+    pub fn pop2_push4<F, E>(&mut self, f: F) -> Result<(), E>
+    where
+        F: FnOnce(Word, Word) -> Result<[Word; 4], E>,
+        E: From<StackError>,
+    {
+        let [w0, w1] = self.pop2()?;
+        let xs = f(w0, w1)?;
+        self.extend(xs)?;
+        Ok(())
+    }
+
+    /// Pop a length value from the top of the stack and return it.
+    pub fn pop_len(&mut self) -> StackResult<usize> {
+        let len_word = self.pop()?;
+        let len = usize::try_from(len_word).map_err(|_| StackError::IndexOutOfBounds)?;
+        Ok(len)
+    }
+
+    /// Pop the length from the top of the stack, then pop and provide that many
+    /// words to the given function.
+    pub fn pop_len_words<F, O, E>(&mut self, f: F) -> Result<O, E>
+    where
+        F: FnOnce(&[Word]) -> Result<O, E>,
+        E: From<StackError>,
+    {
+        let len = self.pop_len()?;
+        let ix = self
+            .len()
+            .checked_sub(len)
+            .ok_or(StackError::IndexOutOfBounds)?;
+        let out = f(&self[ix..])?;
+        self.0.truncate(ix);
+        Ok(out)
+    }
+}
+
+impl From<Stack> for Vec<Word> {
+    fn from(stack: Stack) -> Self {
+        stack.0
+    }
+}
+
+impl From<Vec<Word>> for Stack {
+    fn from(vec: Vec<Word>) -> Self {
+        Self(vec)
+    }
+}
+
+impl core::ops::Deref for Stack {
+    type Target = Vec<Word>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        asm::Stack,
+        error::{ConstraintError, OpError, StackError},
+        eval_ops, exec_ops,
+        test_util::*,
+    };
+
+    #[test]
+    fn dup_from_1() {
+        let ops = &[
+            Stack::Push(42).into(),
+            Stack::Push(2).into(),
+            Stack::Push(1).into(),
+            Stack::Push(0).into(),
+            Stack::Push(3).into(), // Index `3` should be the `42` value.
+            Stack::DupFrom.into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), TEST_ACCESS).unwrap();
+        assert_eq!(&stack[..], &[42, 2, 1, 0, 42]);
+    }
+
+    #[test]
+    fn dup_from_2() {
+        let ops = &[
+            Stack::Push(3).into(),
+            Stack::Push(2).into(),
+            Stack::Push(1).into(),
+            Stack::Push(42).into(),
+            Stack::Push(0).into(), // Index `0` should be the `42` value.
+            Stack::DupFrom.into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), TEST_ACCESS).unwrap();
+        assert_eq!(&stack[..], &[3, 2, 1, 42, 42]);
+    }
+
+    #[test]
+    fn push1() {
+        let ops = &[Stack::Push(42).into()];
+        let stack = exec_ops(ops.iter().copied(), TEST_ACCESS).unwrap();
+        assert_eq!(&stack[..], &[42]);
+    }
+
+    #[test]
+    fn push2_pop_push() {
+        let ops = &[
+            Stack::Push(1).into(),
+            Stack::Push(2).into(),
+            Stack::Pop.into(),
+            Stack::Push(3).into(),
+        ];
+        let stack = exec_ops(ops.iter().copied(), TEST_ACCESS).unwrap();
+        assert_eq!(&stack[..], &[1, 3]);
+    }
+
+    #[test]
+    fn pop_empty() {
+        let ops = &[Stack::Pop.into()];
+        match eval_ops(ops.iter().copied(), TEST_ACCESS) {
+            Err(ConstraintError::Op(0, OpError::Stack(StackError::Empty))) => (),
+            _ => panic!("expected empty stack error"),
+        }
+    }
+
+    #[test]
+    fn index_oob() {
+        let ops = &[Stack::Push(0).into(), Stack::DupFrom.into()];
+        match eval_ops(ops.iter().copied(), TEST_ACCESS) {
+            Err(ConstraintError::Op(1, OpError::Stack(StackError::IndexOutOfBounds))) => (),
+            _ => panic!("expected index out-of-bounds stack error"),
+        }
+    }
+}

--- a/crates/state-read-vm/Cargo.toml
+++ b/crates/state-read-vm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "essential-state-read-vm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+essential-constraint-vm = { workspace = true }
+essential-state-asm = { workspace = true }
+essential-types = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+futures = { workspace = true }
+rand = { workspace = true }
+tokio = { workspace = true }

--- a/crates/state-read-vm/src/bytecode.rs
+++ b/crates/state-read-vm/src/bytecode.rs
@@ -1,0 +1,141 @@
+//! Items related to bytecode representation for the State Read VM.
+
+use crate::asm::{FromBytesError, Op, Opcode};
+
+/// A memory efficient representation of a sequence of operations parsed from bytecode.
+///
+/// State Read execution differs slightly from the Constraint execution in that
+/// State Read operations can include arbitrary control flow.
+///
+/// This means that unlike constraint execution where we reliably parse one
+/// operation at a time, we must store operations in case control flow would
+/// require re-visiting a previous operation.
+///
+/// One simple solution might be to use a `Vec<Op>`, however it is important to
+/// consider that the size of each element within a `Vec<Op>` will be equal to
+/// the size of the discriminant plus the largest `Op` variant size (today, this
+/// is `Push(Word)`, but this may change as new operations are added). This can
+/// have memory requirement implications for programs with large numbers of ops.
+///
+/// To avoid this issue, we instead store the raw "packed" bytecode alongside
+/// a list of indices into the bytecode representing the location of each
+/// operation.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BytecodeMapped {
+    /// The bytecode representation of a program's operations.
+    bytecode: Vec<u8>,
+    /// The index of each op within the bytecode slice.
+    ///
+    /// Indices are guaranteed to be valid by construction and point to a valid operation.
+    op_indices: Vec<usize>,
+}
+
+/// A slice into a [`BytecodeMapped`] instance.
+#[derive(Clone, Copy, Debug)]
+pub struct BytecodeMappedSlice<'a> {
+    /// The full bytecode slice from the original `BytecodeMapped`.
+    bytecode: &'a [u8],
+    /// Some subslice into the `op_indices` of the original `BytecodeMapped`.
+    op_indices: &'a [usize],
+}
+
+impl BytecodeMapped {
+    /// Push a single operation onto the bytecode mapping.
+    pub fn push_op(&mut self, op: Op) {
+        self.op_indices.push(self.bytecode.len());
+        self.bytecode.extend(op.to_bytes());
+    }
+
+    /// The inner slice of bytecode that has been mapped.
+    pub fn bytecode(&self) -> &[u8] {
+        &self.bytecode
+    }
+
+    /// The slice of operation indices within the mapped bytecode.
+    pub fn op_indices(&self) -> &[usize] {
+        &self.op_indices
+    }
+
+    /// Slice the op indices from the given index.
+    ///
+    /// The returned slice represents the remainder of the program from the given op.
+    ///
+    /// Returns `None` if `start` is out of range of the `op_indices` slice.
+    pub fn ops_from(&self, start: usize) -> Option<BytecodeMappedSlice> {
+        Some(BytecodeMappedSlice {
+            bytecode: &self.bytecode,
+            op_indices: self.op_indices.get(start..)?,
+        })
+    }
+
+    /// The operation at the given index.
+    pub fn op(&self, ix: usize) -> Option<Op> {
+        let slice = self.ops_from(ix)?;
+        slice.ops().next()
+    }
+
+    /// An iterator yielding all mapped operations.
+    pub fn ops(&self) -> impl '_ + Iterator<Item = Op> {
+        expect_ops_from_indices(&self.bytecode, self.op_indices.iter().copied())
+    }
+}
+
+impl<'a> BytecodeMappedSlice<'a> {
+    /// The slice of operation indices within the mapped bytecode.
+    pub fn op_indices(self) -> &'a [usize] {
+        self.op_indices
+    }
+
+    /// An iterator yielding all mapped operations represented by this slice.
+    pub fn ops(self) -> impl 'a + Iterator<Item = Op> {
+        expect_ops_from_indices(self.bytecode, self.op_indices.iter().copied())
+    }
+}
+
+// Allow for collecting a `BytecodeMapped` from an iterator over `Op`s.
+impl FromIterator<Op> for BytecodeMapped {
+    fn from_iter<T: IntoIterator<Item = Op>>(iter: T) -> Self {
+        let iter = iter.into_iter();
+        let (min, _) = iter.size_hint();
+        let mut mapped = BytecodeMapped {
+            bytecode: Vec::with_capacity(min),
+            op_indices: Vec::with_capacity(min),
+        };
+        iter.for_each(|op| mapped.push_op(op));
+        mapped
+    }
+}
+
+/// Allow for taking ownership over and mapping an existing `Vec<u8>`.
+impl TryFrom<Vec<u8>> for BytecodeMapped {
+    type Error = FromBytesError;
+    fn try_from(bytecode: Vec<u8>) -> Result<Self, Self::Error> {
+        let mut op_indices = Vec::with_capacity(bytecode.len() / std::mem::size_of::<Op>());
+        let mut iter_enum = bytecode.iter().enumerate();
+        while let Some((ix, &opcode_byte)) = iter_enum.next() {
+            let opcode = Opcode::try_from(opcode_byte)?;
+            let mut op_bytes = iter_enum.by_ref().map(|(_, &byte)| byte);
+            let _op = opcode.parse_op(&mut op_bytes)?;
+            op_indices.push(ix);
+        }
+        Ok(BytecodeMapped {
+            bytecode,
+            op_indices,
+        })
+    }
+}
+
+/// Given a bytecode slice and an operation mapping that is assumed to have been
+/// previously validated, produce an iterator yielding all associated operations.
+fn expect_ops_from_indices<'a>(
+    bytecode: &'a [u8],
+    op_indices: impl 'a + IntoIterator<Item = usize>,
+) -> impl 'a + Iterator<Item = Op> {
+    const EXPECT_MSG: &str = "validated upon construction";
+    op_indices.into_iter().map(|ix| {
+        let mut bytes = bytecode[ix..].iter().copied();
+        Op::from_bytes(&mut bytes)
+            .expect(EXPECT_MSG)
+            .expect(EXPECT_MSG)
+    })
+}

--- a/crates/state-read-vm/src/ctrl_flow.rs
+++ b/crates/state-read-vm/src/ctrl_flow.rs
@@ -1,0 +1,24 @@
+//! ControlFlow operation implementations.
+
+use crate::{
+    error::{ControlFlowError, OpSyncError, OpSyncResult, StackError},
+    types::convert::bool_from_word,
+    Vm,
+};
+
+/// `ControlFlow::Jump` operation.
+pub fn jump(vm: &mut Vm) -> Result<usize, StackError> {
+    let new_pc = vm.stack.pop()?;
+    usize::try_from(new_pc).map_err(|_| StackError::IndexOutOfBounds)
+}
+
+/// `ControlFlow::JumpIf` operation.
+pub fn jump_if(vm: &mut Vm) -> OpSyncResult<usize> {
+    let [new_pc, cond] = vm.stack.pop2()?;
+    let cond = bool_from_word(cond).ok_or(ControlFlowError::InvalidJumpIfCondition(cond))?;
+    let new_pc = match cond {
+        true => usize::try_from(new_pc).map_err(|_| StackError::IndexOutOfBounds)?,
+        false => vm.pc.checked_add(1).ok_or(OpSyncError::PcOverflow)?,
+    };
+    Ok(new_pc)
+}

--- a/crates/state-read-vm/src/error.rs
+++ b/crates/state-read-vm/src/error.rs
@@ -1,0 +1,136 @@
+//! The types of errors that might occur throughout state read execution.
+
+pub use crate::constraint::error::{StackError, StackResult};
+#[doc(inline)]
+use crate::{
+    asm::{self, Word},
+    constraint, Gas,
+};
+use thiserror::Error;
+
+/// Shorthand for a `Result` where the error type is a `StateReadError`.
+pub type StateReadResult<T, E> = Result<T, StateReadError<E>>;
+
+/// Shorthand for a `Result` where the error type is an `OpError`.
+pub type OpResult<T, E> = Result<T, OpError<E>>;
+
+/// Shorthand for a `Result` where the error type is an `OpSyncError`.
+pub type OpSyncResult<T> = Result<T, OpSyncError>;
+
+/// Shorthand for a `Result` where the error type is an `OpAsyncError`.
+pub type OpAsyncResult<T, E> = Result<T, OpAsyncError<E>>;
+
+/// Shorthand for a `Result` where the error type is a `MemoryError`.
+pub type MemoryResult<T> = Result<T, MemoryError>;
+
+/// State read execution failure.
+#[derive(Debug, Error)]
+pub enum StateReadError<E> {
+    /// The operation at the specified index failed.
+    #[error("operation at index {0} failed: {1}")]
+    Op(usize, OpError<E>),
+    /// The program counter is out of range.
+    #[error("program counter {0} out of range (note: programs must end with `Halt`)")]
+    PcOutOfRange(usize),
+}
+
+/// An individual operation failed during state read execution.
+#[derive(Debug, Error)]
+pub enum OpError<E> {
+    /// A synchronous operation failed.
+    #[error("synchronous operation failed: {0}")]
+    Sync(#[from] OpSyncError),
+    /// An asynchronous operation failed.
+    #[error("asynchronous operation failed: {0}")]
+    Async(#[from] OpAsyncError<E>),
+    /// An error occurred while parsing an operation from bytes.
+    #[error("bytecode error: {0}")]
+    FromBytes(#[from] asm::FromBytesError),
+    /// The total gas limit was exceeded.
+    #[error("{0}")]
+    OutOfGas(#[from] OutOfGasError),
+}
+
+/// The gas cost of performing an operation would exceed the gas limit.
+#[derive(Debug, Error)]
+#[error(
+    "operation cost would exceed gas limit\n  \
+    spent: {spent} gas\n  \
+    op cost: {op_gas} gas\n  \
+    limit: {limit} gas"
+)]
+pub struct OutOfGasError {
+    /// Total spent prior to the operation that would exceed the limit.
+    pub spent: Gas,
+    /// The gas required for the operation that failed.
+    pub op_gas: Gas,
+    /// The total gas limit that would be exceeded.
+    pub limit: Gas,
+}
+
+/// A synchronous operation failed.
+#[derive(Debug, Error)]
+pub enum OpSyncError {
+    /// An error occurred during a `Constraint` operation.
+    #[error("constraint operation error: {0}")]
+    Constraint(#[from] constraint::error::OpError),
+    /// An error occurred during a `ControlFlow` operation.
+    #[error("control flow operation error: {0}")]
+    ControlFlow(#[from] ControlFlowError),
+    /// An error occurred during a `Memory` operation.
+    #[error("memory operation error: {0}")]
+    Memory(#[from] MemoryError),
+    /// The next program counter would overflow.
+    #[error("the next program counter would overflow")]
+    PcOverflow,
+}
+
+/// A synchronous operation failed.
+#[derive(Debug, Error)]
+pub enum OpAsyncError<E> {
+    /// An error occurred during a `StateRead` operation.
+    #[error("state read operation error: {0}")]
+    StateRead(E),
+    /// A `Memory` access related error occurred.
+    #[error("memory error: {0}")]
+    Memory(#[from] MemoryError),
+    /// An error occurred during a `Stack` operation.
+    #[error("stack operation error: {0}")]
+    Stack(#[from] StackError),
+    /// The next program counter would overflow.
+    #[error("the next program counter would overflow")]
+    PcOverflow,
+}
+
+/// Errors occuring during `ControlFlow` operation.
+#[derive(Debug, Error)]
+pub enum ControlFlowError {
+    /// A `JumpIf` operation encountered an invalid condition.
+    ///
+    /// Condition values must be 0 (false) or 1 (true).
+    #[error("invalid condition value {0}, expected 0 (false) or 1 (true)")]
+    InvalidJumpIfCondition(Word),
+}
+
+/// Errors occuring during `Memory` operation.
+#[derive(Debug, Error)]
+pub enum MemoryError {
+    /// Attempted to access a memory index that was out of bounds.
+    #[error("index out of bounds")]
+    IndexOutOfBounds,
+    /// An operation would have caused memory to overflow.
+    #[error("operation would cause memory to overflow")]
+    Overflow,
+}
+
+impl<E> From<core::convert::Infallible> for OpError<E> {
+    fn from(err: core::convert::Infallible) -> Self {
+        match err {}
+    }
+}
+
+impl From<StackError> for OpSyncError {
+    fn from(err: StackError) -> Self {
+        OpSyncError::Constraint(err.into())
+    }
+}

--- a/crates/state-read-vm/src/future.rs
+++ b/crates/state-read-vm/src/future.rs
@@ -1,0 +1,340 @@
+use crate::{
+    error::{OpAsyncError, OpError, OutOfGasError, StateReadError},
+    state_read::{self, StateReadFuture},
+    step_op_sync, Access, ContentAddress, Gas, GasLimit, OpAccess, OpAsync, OpAsyncResult,
+    OpGasCost, OpKind, StateRead, Vm,
+};
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// A future that when polled attempts to make progress on VM execution.
+///
+/// This poll implementation steps forward the VM by the stored operations,
+/// handling synchronous and asynchronous operations differently:
+///
+/// - For synchronous operations, it directly steps the VM to execute the
+///   operation.
+/// - For asynchronous operations, it creates a future that will complete
+///   the operation and temporarily takes ownership of the VM. This future
+///   is stored in `pending_op` until it's ready.
+///
+/// This type should not be constructed directly. Instead, it is used as a part
+/// of the implementation of [`Vm::exec`] and exposed publicly for documentation
+/// of its behaviour.
+///
+/// ## Yield Behavior
+///
+/// Execution yields in two scenarios:
+///
+/// - **Asynchronous Operations**: When an async operation is encountered,
+///   the method yields until the operation's future is ready. This allows
+///   other tasks to run while awaiting the asynchronous operation to
+///   complete.
+/// - **Gas Yield Limit Reached**: The method also yields based on a gas
+///   spending limit. If executing an operation causes `gas.spent` to exceed
+///   `gas.next_yield_threshold`, the method yields to allow the scheduler
+///   to run other tasks. This prevents long or complex sequences of
+///   operations from monopolizing CPU time.
+///
+/// Upon yielding, the method ensures that the state of the VM and the
+/// execution context (including gas counters and any pending operations)
+/// are preserved for when the `poll` method is called again.
+///
+/// ## Error Handling
+///
+/// Errors encountered during operation execution result in an immediate
+/// return of `Poll::Ready(Err(...))`, encapsulating the error within a
+/// `StateReadError`. This includes errors from:
+///
+/// - Synchronous operations that fail during their execution.
+/// - Asynchronous operations, where errors are handled once the future
+///   resolves.
+///
+/// The VM's program counter will remain on the operation that caused the
+/// error.
+///
+/// ## Completion
+///
+/// The future completes (`Poll::Ready(Ok(...))`) when all operations have
+/// been executed and no more work remains. At this point, ownership over
+/// the VM is dropped and the total amount of gas spent during execution is
+/// returned. Attempting to poll the future after completion will panic.
+pub struct ExecFuture<'a, S, OA, OG>
+where
+    S: StateRead,
+{
+    /// Access to solution data.
+    access: Access<'a>,
+    /// Access to state reading.
+    state_read: &'a S,
+    /// Access to operations.
+    op_access: OA,
+    /// A function that, given a reference to an op, returns its gas cost.
+    op_gas_cost: &'a OG,
+    /// Store the VM in an `Option` so that we can `take` it upon future completion.
+    vm: Option<&'a mut Vm>,
+    /// Gas spent during execution so far.
+    gas: GasExec,
+    /// In the case that the operation future is pending (i.e a state read is in
+    /// progress), we store the future here.
+    pending_op: Option<PendingOp<'a, S>>,
+}
+
+/// Track gas limits and expenditure for execution.
+struct GasExec {
+    /// The total and yield gas limits.
+    limit: GasLimit,
+    /// The gas threshold at which the future should yield.
+    next_yield_threshold: Gas,
+    /// The total gas limit.
+    spent: Gas,
+}
+
+/// Encapsulates a pending operation.
+struct PendingOp<'a, S>
+where
+    S: StateRead,
+{
+    // The future representing the operation in progress.
+    future: StepOpAsyncFuture<'a, S>,
+    /// Total gas that will have been spent upon completing the op.
+    next_spent: Gas,
+}
+
+/// The future type produced when performing an async operation.
+enum StepOpAsyncFuture<'a, S>
+where
+    S: StateRead,
+{
+    /// The async `StateRead::WordRange` (or `WordRangeExtern`) operation future.
+    StateRead(StateReadFuture<'a, S>),
+}
+
+impl From<GasLimit> for GasExec {
+    /// Initialise gas execution tracking from a given gas limit.
+    fn from(limit: GasLimit) -> Self {
+        GasExec {
+            spent: 0,
+            next_yield_threshold: limit.per_yield,
+            limit,
+        }
+    }
+}
+
+// Allow for consuming the async operation future to retake ownership of the stored `&mut Vm`.
+impl<'a, S> From<StepOpAsyncFuture<'a, S>> for &'a mut Vm
+where
+    S: StateRead,
+{
+    fn from(future: StepOpAsyncFuture<'a, S>) -> Self {
+        match future {
+            StepOpAsyncFuture::StateRead(future) => future.vm,
+        }
+    }
+}
+
+impl<'a, S, OA, OG> Future for ExecFuture<'a, S, OA, OG>
+where
+    S: StateRead,
+    OA: OpAccess + Unpin,
+    OG: OpGasCost,
+    OA::Error: Into<OpError<S::Error>>,
+{
+    /// Returns a result with the total gas spent.
+    type Output = Result<Gas, StateReadError<S::Error>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        // Poll the async operation future if there is one pending.
+        let vm = match self.pending_op.as_mut() {
+            None => self.vm.take().expect("future polled after completion"),
+            Some(pending) => {
+                let res = match Pin::new(&mut pending.future).poll(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(ready) => ready,
+                };
+
+                // Drop the future now we've resumed, retake ownership of the `&mut Vm`.
+                let pending = self.pending_op.take().expect("guaranteed `Some`");
+                let next_spent = pending.next_spent;
+                let vm: &'a mut Vm = pending.future.into();
+
+                // Handle the op result.
+                match res {
+                    Ok(new_pc) => vm.pc = new_pc,
+                    Err(err) => {
+                        let err = StateReadError::Op(vm.pc, err.into());
+                        return Poll::Ready(Err(err));
+                    }
+                };
+
+                // Update gas spent and threshold now that we've resumed.
+                self.gas.spent = next_spent;
+                self.gas.next_yield_threshold =
+                    self.gas.spent.saturating_add(self.gas.limit.per_yield);
+                vm
+            }
+        };
+
+        // Step forward the virtual machine by the next operation.
+        while let Some(res) = self.op_access.op_access(vm.pc) {
+            // Handle any potential operation access error.
+            let op = match res {
+                Ok(op) => op,
+                Err(err) => {
+                    let err = StateReadError::Op(vm.pc, err.into());
+                    return Poll::Ready(Err(err));
+                }
+            };
+
+            let op_gas = self.op_gas_cost.op_gas_cost(&op);
+
+            // Check that the operation wouldn't exceed gas limit.
+            let next_spent = match self
+                .gas
+                .spent
+                .checked_add(op_gas)
+                .filter(|&spent| spent <= self.gas.limit.total)
+                .ok_or_else(|| out_of_gas(&self.gas, op_gas))
+                .map_err(|err| StateReadError::Op(vm.pc, err.into()))
+            {
+                Err(err) => return Poll::Ready(Err(err)),
+                Ok(next_spent) => next_spent,
+            };
+
+            let res = match OpKind::from(op) {
+                OpKind::Sync(op) => step_op_sync(op, self.access, vm),
+                OpKind::Async(op) => {
+                    // Async op takes ownership of the VM and returns it upon future completion.
+                    let set_addr = self.access.solution.this_data().intent_to_solve.set.clone();
+                    let pc = vm.pc;
+                    let future = match step_op_async(op, set_addr, self.state_read, vm) {
+                        Err(err) => {
+                            let err = StateReadError::Op(pc, err.into());
+                            return Poll::Ready(Err(err));
+                        }
+                        Ok(fut) => fut,
+                    };
+                    self.pending_op = Some(PendingOp { future, next_spent });
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+            };
+
+            // Handle any errors.
+            let opt_new_pc = match res {
+                Ok(opt) => opt,
+                Err(err) => {
+                    let err = StateReadError::Op(vm.pc, err.into());
+                    return Poll::Ready(Err(err));
+                }
+            };
+
+            // Operation successful, so update gas spent.
+            self.gas.spent = next_spent;
+
+            // Update the program counter, or exit if we're done.
+            match opt_new_pc {
+                Some(new_pc) => vm.pc = new_pc,
+                // `None` is returned after encountering a `Halt` operation.
+                None => return Poll::Ready(Ok(self.gas.spent)),
+            }
+
+            // Yield if we've reached our gas limit.
+            if self.gas.next_yield_threshold <= self.gas.spent {
+                self.gas.next_yield_threshold =
+                    self.gas.spent.saturating_add(self.gas.limit.per_yield);
+                self.vm = Some(vm);
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+        }
+
+        // Programs must complete with a `Halt` operation.
+        Poll::Ready(Err(StateReadError::PcOutOfRange(vm.pc)))
+    }
+}
+
+impl<'vm, S> Future for StepOpAsyncFuture<'vm, S>
+where
+    S: StateRead,
+{
+    // Future returns a result with the new program counter.
+    type Output = OpAsyncResult<usize, S::Error>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let (prev_pc, res) = match *self {
+            Self::StateRead(ref mut future) => {
+                let pc = future.vm.pc;
+                match Pin::new(future).poll(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(res) => (pc, res),
+                }
+            }
+        };
+        // Every operation besides control flow steps forward program counter by 1.
+        let new_pc = prev_pc.checked_add(1).ok_or(OpAsyncError::PcOverflow)?;
+        let res = res.map(|()| new_pc);
+        Poll::Ready(res)
+    }
+}
+
+/// Creates the VM execution future.
+pub(crate) fn exec<'a, S, OA, OG>(
+    vm: &'a mut Vm,
+    access: Access<'a>,
+    state_read: &'a S,
+    op_access: OA,
+    op_gas_cost: &'a OG,
+    gas_limit: GasLimit,
+) -> ExecFuture<'a, S, OA, OG>
+where
+    S: StateRead,
+    OA: OpAccess + Unpin,
+    OG: OpGasCost,
+    OA::Error: Into<OpError<S::Error>>,
+{
+    ExecFuture {
+        access,
+        state_read,
+        op_access,
+        op_gas_cost,
+        vm: Some(vm),
+        gas: GasExec::from(gas_limit),
+        pending_op: None,
+    }
+}
+
+/// Step forward the given `Vm` with the given asynchronous operation.
+///
+/// Returns a future representing the completion of the operation.
+fn step_op_async<'a, S>(
+    op: OpAsync,
+    set_addr: ContentAddress,
+    state_read: &'a S,
+    vm: &'a mut Vm,
+) -> OpAsyncResult<StepOpAsyncFuture<'a, S>, S::Error>
+where
+    S: StateRead,
+{
+    match op {
+        OpAsync::StateReadWordRange => {
+            let future = state_read::word_range(state_read, &set_addr, &mut *vm)?;
+            Ok(StepOpAsyncFuture::StateRead(future))
+        }
+        OpAsync::StateReadWordRangeExt => {
+            let future = state_read::word_range_ext(state_read, &mut *vm)?;
+            Ok(StepOpAsyncFuture::StateRead(future))
+        }
+    }
+}
+
+/// Shorthand for constructing an `OutOfGasError`.
+fn out_of_gas(exec: &GasExec, op_gas: Gas) -> OutOfGasError {
+    OutOfGasError {
+        spent: exec.spent,
+        limit: exec.limit.total,
+        op_gas,
+    }
+}

--- a/crates/state-read-vm/src/lib.rs
+++ b/crates/state-read-vm/src/lib.rs
@@ -1,0 +1,371 @@
+//! The essential state read VM implementation.
+//!
+//! ## Reading State
+//!
+//! The primary entrypoint for this crate is the [`Vm` type][Vm].
+//!
+//! The `Vm` allows for executing operations that read state and apply any
+//! necessary operations in order to form the final, expected state slot layout
+//! within the VM's [`Memory`]. The `Vm`'s memory can be accessed directly
+//! from the `Vm`, or the `Vm` can be consumed and state slots returned with
+//! [`Vm::into_state_slots`].
+//!
+//! ## Executing Ops
+//!
+//! There are three primary methods available for executing operations:
+//!
+//! - [`Vm::exec_ops`]
+//! - [`Vm::exec_bytecode`]
+//! - [`Vm::exec_bytecode_iter`]
+//!
+//! Each have slightly different performance implications, so be sure to read
+//! the docs before selecting a method.
+//!
+//! ## Execution Future
+//!
+//! The `Vm::exec_*` functions all return `Future`s that not only yield on
+//! async operations, but yield based on a user-specified gas limit too. See the
+//! [`ExecFuture`] docs for further details on the implementation.
+#![deny(missing_docs, unsafe_code)]
+
+#[doc(inline)]
+pub use bytecode::{BytecodeMapped, BytecodeMappedSlice};
+use error::{MemoryError, OpError, OpSyncError, StateReadError};
+#[doc(inline)]
+pub use error::{MemoryResult, OpAsyncResult, OpResult, OpSyncResult, StateReadResult};
+#[doc(inline)]
+pub use essential_constraint_vm::{
+    self as constraint, Access, SolutionAccess, Stack, StateSlotSlice, StateSlots,
+};
+#[doc(inline)]
+pub use essential_state_asm as asm;
+use essential_state_asm::Op;
+pub use essential_types as types;
+use essential_types::{ContentAddress, Word};
+#[doc(inline)]
+pub use future::ExecFuture;
+pub use memory::Memory;
+pub use state_read::StateRead;
+
+mod bytecode;
+mod ctrl_flow;
+pub mod error;
+mod future;
+mod memory;
+mod state_read;
+
+/// The operation execution state of the State Read VM.
+#[derive(Debug, Default, PartialEq)]
+pub struct Vm {
+    /// The program counter, i.e. index of the current operation within the program.
+    pub pc: usize,
+    /// The stack machine.
+    pub stack: Stack,
+    /// The program memory, primarily used for collecting the state being read.
+    pub memory: Memory,
+}
+
+/// Unit used to measure gas.
+pub type Gas = u64;
+
+/// Gas limits.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct GasLimit {
+    /// The amount that may be spent synchronously until the execution future should yield.
+    pub per_yield: Gas,
+    /// The total amount of gas that may be spent.
+    pub total: Gas,
+}
+
+/// Distinguish between sync and async ops to ease `Future` implementation.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub(crate) enum OpKind {
+    /// Operations that yield immediately.
+    Sync(OpSync),
+    /// Operations returning a future.
+    Async(OpAsync),
+}
+
+/// The set of operations performed synchronously.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub(crate) enum OpSync {
+    /// All operations available to the constraint checker.
+    Constraint(asm::Constraint),
+    /// Operations for controlling the flow of the program.
+    ControlFlow(asm::ControlFlow),
+    /// Operations for controlling the flow of the program.
+    Memory(asm::Memory),
+}
+
+/// The set of operations that are performed asynchronously.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub(crate) enum OpAsync {
+    /// Read a range of words from state starting at the key.
+    StateReadWordRange,
+    /// Read a range of words from external state starting at the key.
+    StateReadWordRangeExt,
+}
+
+/// Types that provide access to operations.
+///
+/// Implementations are included for `&[Op]`, `BytecodeMapped` and more.
+pub trait OpAccess {
+    /// Any error that might occur during access.
+    type Error: std::error::Error;
+    /// Access the operation at the given index.
+    ///
+    /// Mutable access to self is required in case operations are lazily parsed.
+    ///
+    /// Any implementation should ensure the same index always returns the same operation.
+    fn op_access(&mut self, index: usize) -> Option<Result<Op, Self::Error>>;
+}
+
+/// A mapping from an operation to its gas cost.
+pub trait OpGasCost {
+    /// The gas cost associated with the given op.
+    fn op_gas_cost(&self, op: &Op) -> Gas;
+}
+
+impl GasLimit {
+    /// The default value used for the `per_yield` limit.
+    // TODO: Adjust this to match recommended poll time limit on supported validator
+    // hardware.
+    pub const DEFAULT_PER_YIELD: Gas = 4_096;
+
+    /// Unlimited gas limit with default gas-per-yield.
+    pub const UNLIMITED: Self = Self {
+        per_yield: Self::DEFAULT_PER_YIELD,
+        total: Gas::MAX,
+    };
+}
+
+impl Vm {
+    /// Execute the given operations from the current state of the VM.
+    ///
+    /// Upon reaching a `Halt` operation or reaching the end of the operation
+    /// sequence, returns the gas spent and the `Vm` will be left in the
+    /// resulting state.
+    ///
+    /// This is a wrapper around [`Vm::exec`] that expects operation access in
+    /// the form of a `&[Op]`.
+    ///
+    /// If memory bloat is a concern, consider using the [`Vm::exec_bytecode`]
+    /// or [`Vm::exec_bytecode_iter`] methods which allow for providing a more
+    /// compact representation of the operations in the form of mapped bytecode.
+    pub async fn exec_ops<'a, S>(
+        &mut self,
+        ops: &[Op],
+        access: Access<'a>,
+        state_read: &S,
+        op_gas_cost: &impl OpGasCost,
+        gas_limit: GasLimit,
+    ) -> Result<Gas, StateReadError<S::Error>>
+    where
+        S: StateRead,
+    {
+        self.exec(access, state_read, ops, op_gas_cost, gas_limit)
+            .await
+    }
+
+    /// Execute the given mapped bytecode from the current state of the VM.
+    ///
+    /// Upon reaching a `Halt` operation or reaching the end of the operation
+    /// sequence, returns the gas spent and the `Vm` will be left in the
+    /// resulting state.
+    ///
+    /// This is a wrapper around [`Vm::exec`] that expects operation access in
+    /// the form of [`&BytecodeMapped`][BytecodeMapped].
+    ///
+    /// This can be a more memory efficient alternative to [`Vm::exec_ops`] due
+    /// to the compact representation of operations in the form of bytecode and
+    /// indices.
+    pub async fn exec_bytecode<'a, S>(
+        &mut self,
+        bytecode_mapped: &BytecodeMapped,
+        access: Access<'a>,
+        state_read: &S,
+        op_gas_cost: &impl OpGasCost,
+        gas_limit: GasLimit,
+    ) -> Result<Gas, StateReadError<S::Error>>
+    where
+        S: StateRead,
+    {
+        self.exec(access, state_read, bytecode_mapped, op_gas_cost, gas_limit)
+            .await
+    }
+
+    /// Execute the given bytecode from the current state of the VM.
+    ///
+    /// Upon reaching a `Halt` operation or reaching the end of the operation
+    /// sequence, returns the gas spent and the `Vm` will be left in the
+    /// resulting state.
+    ///
+    /// The given bytecode will be mapped lazily during execution. This
+    /// can be more efficient than pre-mapping the bytecode and using
+    /// [`Vm::exec_bytecode`] in the case that execution may fail early.
+    ///
+    /// However, successful execution still requires building the full
+    /// [`BytecodeMapped`] instance internally. So if bytecode has already been
+    /// mapped, [`Vm::exec_bytecode`] should be preferred.
+    pub async fn exec_bytecode_iter<'a, S, I>(
+        &mut self,
+        bytecode_iter: I,
+        access: Access<'a>,
+        state_read: &S,
+        op_gas_cost: &impl OpGasCost,
+        gas_limit: GasLimit,
+    ) -> Result<Gas, StateReadError<S::Error>>
+    where
+        S: StateRead,
+        I: IntoIterator<Item = u8>,
+        I::IntoIter: Unpin,
+    {
+        /// A type wrapper around `BytecodeMapped` that lazily constructs the
+        /// map from the given bytecode as operations are accessed.
+        struct BytecodeMappedLazy<I> {
+            mapped: BytecodeMapped,
+            iter: I,
+        }
+
+        // Op access lazily populates operations from the given byte iterator
+        // as necessary.
+        impl<I> OpAccess for BytecodeMappedLazy<I>
+        where
+            I: Iterator<Item = u8>,
+        {
+            type Error = asm::FromBytesError;
+            fn op_access(&mut self, index: usize) -> Option<Result<Op, Self::Error>> {
+                loop {
+                    match self.mapped.op(index) {
+                        Some(op) => return Some(Ok(op)),
+                        None => match Op::from_bytes(&mut self.iter)? {
+                            Err(err) => return Some(Err(err)),
+                            Ok(op) => self.mapped.push_op(op),
+                        },
+                    }
+                }
+            }
+        }
+
+        let bytecode_lazy = BytecodeMappedLazy {
+            mapped: BytecodeMapped::default(),
+            iter: bytecode_iter.into_iter(),
+        };
+        self.exec(access, state_read, bytecode_lazy, op_gas_cost, gas_limit)
+            .await
+    }
+
+    /// Execute over the given operation access from the current state of the VM.
+    ///
+    /// Upon reaching a `Halt` operation or reaching the end of the operation
+    /// sequence, returns the gas spent and the `Vm` will be left in the
+    /// resulting state.
+    ///
+    /// The type requirements for the `op_access` argument can make this
+    /// finicky to use directly. You may prefer one of the convenience methods:
+    ///
+    /// - [`Vm::exec_ops`]
+    /// - [`Vm::exec_bytecode`]
+    /// - [`Vm::exec_bytecode_iter`]
+    pub async fn exec<'a, S, OA>(
+        &mut self,
+        access: Access<'a>,
+        state_read: &S,
+        op_access: OA,
+        op_gas_cost: &impl OpGasCost,
+        gas_limit: GasLimit,
+    ) -> Result<Gas, StateReadError<S::Error>>
+    where
+        S: StateRead,
+        OA: OpAccess + Unpin,
+        OA::Error: Into<OpError<S::Error>>,
+    {
+        future::exec(self, access, state_read, op_access, op_gas_cost, gas_limit).await
+    }
+
+    /// Consumes the `Vm` and returns the read state slots.
+    ///
+    /// The returned slots correspond directly with the current memory content.
+    pub fn into_state_slots(self) -> Vec<Option<Word>> {
+        self.memory.into()
+    }
+}
+
+impl From<Op> for OpKind {
+    fn from(op: Op) -> Self {
+        match op {
+            Op::Constraint(op) => OpKind::Sync(OpSync::Constraint(op)),
+            Op::ControlFlow(op) => OpKind::Sync(OpSync::ControlFlow(op)),
+            Op::Memory(op) => OpKind::Sync(OpSync::Memory(op)),
+            Op::WordRange => OpKind::Async(OpAsync::StateReadWordRange),
+            Op::WordRangeExtern => OpKind::Async(OpAsync::StateReadWordRangeExt),
+        }
+    }
+}
+
+impl<F> OpGasCost for F
+where
+    F: Fn(&Op) -> Gas,
+{
+    fn op_gas_cost(&self, op: &Op) -> Gas {
+        (*self)(op)
+    }
+}
+
+impl<'a> OpAccess for &'a [Op] {
+    type Error = core::convert::Infallible;
+    fn op_access(&mut self, index: usize) -> Option<Result<Op, Self::Error>> {
+        self.get(index).copied().map(Ok)
+    }
+}
+
+impl<'a> OpAccess for &'a BytecodeMapped {
+    type Error = core::convert::Infallible;
+    fn op_access(&mut self, index: usize) -> Option<Result<Op, Self::Error>> {
+        self.op(index).map(Ok)
+    }
+}
+
+/// Step forward the VM by a single synchronous operation.
+///
+/// Returns a `Some(usize)` representing the new program counter resulting from
+/// this step, or `None` in the case that execution has halted.
+pub(crate) fn step_op_sync(op: OpSync, access: Access, vm: &mut Vm) -> OpSyncResult<Option<usize>> {
+    match op {
+        OpSync::Constraint(op) => constraint::step_op(access, op, &mut vm.stack)?,
+        OpSync::ControlFlow(op) => return step_op_ctrl_flow(op, vm).map_err(From::from),
+        OpSync::Memory(op) => step_op_memory(op, &mut *vm)?,
+    }
+    // Every operation besides control flow steps forward program counter by 1.
+    let new_pc = vm.pc.checked_add(1).ok_or(OpSyncError::PcOverflow)?;
+    Ok(Some(new_pc))
+}
+
+/// Step forward state reading by the given control flow operation.
+///
+/// Returns a `bool` indicating whether or not to continue execution.
+pub(crate) fn step_op_ctrl_flow(op: asm::ControlFlow, vm: &mut Vm) -> OpSyncResult<Option<usize>> {
+    match op {
+        asm::ControlFlow::Jump => ctrl_flow::jump(vm).map(Some).map_err(From::from),
+        asm::ControlFlow::JumpIf => ctrl_flow::jump_if(vm).map(Some),
+        asm::ControlFlow::Halt => Ok(None),
+    }
+}
+
+/// Step forward state reading by the given memory operation.
+pub(crate) fn step_op_memory(op: asm::Memory, vm: &mut Vm) -> OpSyncResult<()> {
+    match op {
+        asm::Memory::Alloc => memory::alloc(vm),
+        asm::Memory::Capacity => memory::capacity(vm),
+        asm::Memory::Clear => memory::clear(vm),
+        asm::Memory::ClearRange => memory::clear_range(vm),
+        asm::Memory::Free => memory::free(vm),
+        asm::Memory::IsSome => memory::is_some(vm),
+        asm::Memory::Length => memory::length(vm),
+        asm::Memory::Load => memory::load(vm),
+        asm::Memory::Push => memory::push(vm),
+        asm::Memory::PushNone => memory::push_none(vm),
+        asm::Memory::Store => memory::store(vm),
+        asm::Memory::Truncate => memory::truncate(vm),
+    }
+}

--- a/crates/state-read-vm/src/memory.rs
+++ b/crates/state-read-vm/src/memory.rs
@@ -1,0 +1,207 @@
+//! Memory operation implementations and related items.
+
+use crate::{asm::Word, MemoryError, MemoryResult, OpSyncResult, Vm};
+
+/// A type representing the VM's memory.
+///
+/// `Memory` is a thin wrapper around a `Vec<Option<Word>>`. The `Vec` mutable methods
+/// are intentionally not exposed in order to maintain close control over capacity.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Memory(Vec<Option<Word>>);
+
+impl Memory {
+    /// The maximum number of words stored in memory.
+    ///
+    /// This results in `4096` * the size of `Option<Word>`.
+    pub const SIZE_LIMIT: usize = 4096;
+
+    /// Allocate new capacity to the end of the memory.
+    pub fn alloc(&mut self, size: usize) -> MemoryResult<()> {
+        if self.capacity() + size > Self::SIZE_LIMIT {
+            return Err(MemoryError::Overflow);
+        }
+        self.0.reserve_exact(size);
+        Ok(())
+    }
+
+    /// Set the value at the given index to `None`.
+    pub fn clear(&mut self, index: usize) -> MemoryResult<()> {
+        *self.0.get_mut(index).ok_or(MemoryError::IndexOutOfBounds)? = None;
+        Ok(())
+    }
+
+    /// Set the values over the given range to `None`.
+    pub fn clear_range(&mut self, range: core::ops::Range<usize>) -> MemoryResult<()> {
+        self.0
+            .get_mut(range)
+            .ok_or(MemoryError::IndexOutOfBounds)?
+            .iter_mut()
+            .for_each(|val| *val = None);
+        Ok(())
+    }
+
+    /// Free the specified amount of memory from the end.
+    pub fn free(&mut self, size: usize) {
+        let new_size = self.capacity().saturating_sub(size);
+        self.0.shrink_to(new_size);
+    }
+
+    /// Check whether the value at the given index is `Some`.
+    pub fn is_some(&self, index: usize) -> MemoryResult<bool> {
+        let opt = self.get(index).ok_or(MemoryError::IndexOutOfBounds)?;
+        Ok(opt.is_some())
+    }
+
+    /// Load a word at the given index.
+    pub fn load(&self, index: usize) -> MemoryResult<Word> {
+        let opt = self.get(index).ok_or(MemoryError::IndexOutOfBounds)?;
+        Ok(opt.unwrap_or(Word::default()))
+    }
+
+    /// Push a word to the stack.
+    pub fn push(&mut self, opt: Option<Word>) -> MemoryResult<()> {
+        if self.len() >= self.capacity() {
+            return Err(MemoryError::Overflow);
+        }
+        self.0.push(opt);
+        Ok(())
+    }
+
+    /// Extend memory with the given values.
+    pub fn extend(&mut self, words: Vec<Option<Word>>) -> MemoryResult<()> {
+        let new_len = self
+            .len()
+            .checked_add(words.len())
+            .ok_or(MemoryError::Overflow)?;
+        if new_len > self.capacity() {
+            return Err(MemoryError::Overflow);
+        }
+        self.0.extend(words);
+        Ok(())
+    }
+
+    /// Store the given `word` at the given `index`.
+    pub fn store(&mut self, index: usize, value: Word) -> MemoryResult<()> {
+        let opt = self.0.get_mut(index).ok_or(MemoryError::IndexOutOfBounds)?;
+        *opt = Some(value);
+        Ok(())
+    }
+
+    /// Truncate `Memory` to the given new length.
+    pub fn truncate(&mut self, new_len: usize) {
+        self.0.truncate(new_len);
+    }
+}
+
+impl core::ops::Deref for Memory {
+    type Target = Vec<Option<Word>>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Memory> for Vec<Option<Word>> {
+    fn from(memory: Memory) -> Self {
+        memory.0
+    }
+}
+
+/// `Memory::Alloc` operation.
+pub fn alloc(vm: &mut Vm) -> OpSyncResult<()> {
+    let size = vm.stack.pop()?;
+    let size = usize::try_from(size).map_err(|_| MemoryError::IndexOutOfBounds)?;
+    vm.memory.alloc(size)?;
+    Ok(())
+}
+
+/// `Memory::Capacity` operation.
+pub fn capacity(vm: &mut Vm) -> OpSyncResult<()> {
+    let cap = Word::try_from(vm.memory.capacity()).map_err(|_| MemoryError::IndexOutOfBounds)?;
+    vm.stack.push(cap)?;
+    Ok(())
+}
+
+/// `Memory::Clear` operation.
+pub fn clear(vm: &mut Vm) -> OpSyncResult<()> {
+    let index = vm.stack.pop()?;
+    let index = usize::try_from(index).map_err(|_| MemoryError::IndexOutOfBounds)?;
+    vm.memory.clear(index)?;
+    Ok(())
+}
+
+/// `Memory::Clear` operation.
+pub fn clear_range(vm: &mut Vm) -> OpSyncResult<()> {
+    let [index, len] = vm.stack.pop2()?;
+    let range = range_from_start_len(index, len).ok_or(MemoryError::IndexOutOfBounds)?;
+    vm.memory.clear_range(range)?;
+    Ok(())
+}
+
+/// `Memory::Free` operation.
+pub fn free(vm: &mut Vm) -> OpSyncResult<()> {
+    let size = vm.stack.pop()?;
+    let size = usize::try_from(size).map_err(|_| MemoryError::IndexOutOfBounds)?;
+    vm.memory.free(size);
+    Ok(())
+}
+
+// `Memory::IsSome` operation.
+pub fn is_some(vm: &mut Vm) -> OpSyncResult<()> {
+    let index = vm.stack.pop()?;
+    let index = usize::try_from(index).map_err(|_| MemoryError::IndexOutOfBounds)?;
+    let is_some = vm.memory.is_some(index)?;
+    vm.stack.push(is_some.into())?;
+    Ok(())
+}
+
+/// `Memory::Capacity` operation.
+pub fn length(vm: &mut Vm) -> OpSyncResult<()> {
+    let cap = Word::try_from(vm.memory.len()).map_err(|_| MemoryError::IndexOutOfBounds)?;
+    vm.stack.push(cap)?;
+    Ok(())
+}
+
+/// `Memory::Load` operation.
+pub fn load(vm: &mut Vm) -> OpSyncResult<()> {
+    let index = vm.stack.pop()?;
+    let index = usize::try_from(index).map_err(|_| MemoryError::IndexOutOfBounds)?;
+    let word = vm.memory.load(index)?;
+    vm.stack.push(word)?;
+    Ok(())
+}
+
+/// `Memory::Push` operation.
+pub fn push(vm: &mut Vm) -> OpSyncResult<()> {
+    let word = vm.stack.pop()?;
+    vm.memory.push(Some(word))?;
+    Ok(())
+}
+
+/// `Memory::PushNone` operation.
+pub fn push_none(vm: &mut Vm) -> OpSyncResult<()> {
+    vm.memory.push(None)?;
+    Ok(())
+}
+
+/// `Memory::Store` operation.
+pub fn store(vm: &mut Vm) -> OpSyncResult<()> {
+    let [index, value] = vm.stack.pop2()?;
+    let index = usize::try_from(index).map_err(|_| MemoryError::IndexOutOfBounds)?;
+    vm.memory.store(index, value)?;
+    Ok(())
+}
+
+/// `Memory::Truncate` operation.
+pub fn truncate(vm: &mut Vm) -> OpSyncResult<()> {
+    let len = vm.stack.pop()?;
+    let len = usize::try_from(len).map_err(|_| MemoryError::IndexOutOfBounds)?;
+    vm.memory.truncate(len);
+    Ok(())
+}
+
+fn range_from_start_len(start: Word, len: Word) -> Option<std::ops::Range<usize>> {
+    let start = usize::try_from(start).ok()?;
+    let len = usize::try_from(len).ok()?;
+    let end = start.checked_add(len)?;
+    Some(start..end)
+}

--- a/crates/state-read-vm/src/state_read.rs
+++ b/crates/state-read-vm/src/state_read.rs
@@ -1,0 +1,130 @@
+//! State read operation implementations.
+
+use crate::{
+    error::{OpAsyncError, StackError},
+    OpAsyncResult, Vm,
+};
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use essential_types::{convert::u8_32_from_word_4, ContentAddress, Key, Word};
+
+/// Access to state required by the state read VM.
+pub trait StateRead {
+    /// An error type describing any cases that might occur during state reading.
+    type Error: std::error::Error;
+    /// The future type returned from the `word_range` method.
+    ///
+    /// ## Unpin
+    ///
+    /// This `Future` must be `Unpin` in order for the `Vm`'s `ExecFuture`
+    /// to remain zero-allocation by default. Implementers may decide on
+    /// whether they require dynamic allocation as a part of their `StateRead`
+    /// implementation.
+    ///
+    /// It is likely that in-memory implementations may be `Unpin` by default
+    /// using `std::future::Ready`, however more involved implementations that
+    /// require calling `async` functions with anonymised return types may
+    /// require using a `Box` in order to name the anonymised type.
+    type Future: Future<Output = Result<Vec<Option<Word>>, Self::Error>> + Unpin;
+
+    /// Read the given number of words from state at the given key associated
+    /// with the given intent set address.
+    fn word_range(&self, set_addr: ContentAddress, key: Key, num_words: usize) -> Self::Future;
+}
+
+/// A future representing the asynchronous `StateRead` (or `StateReadExtern`) operation.
+///
+/// Performs the state read and then writes the result to memory.
+pub(crate) struct StateReadFuture<'vm, S>
+where
+    S: StateRead,
+{
+    /// The future produced by the `StateRead::word_range` implementation.
+    future: S::Future,
+    /// Access to the `Vm` so that the result of the future can be written to memory.
+    pub(crate) vm: &'vm mut Vm,
+}
+
+impl<'vm, S> Future for StateReadFuture<'vm, S>
+where
+    S: StateRead,
+{
+    /// Returns a `Result` representing whether or not the state was read and
+    /// written to memory successfully.
+    type Output = OpAsyncResult<(), S::Error>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        match Pin::new(&mut self.future).poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(res) => {
+                let res = res
+                    .map_err(OpAsyncError::StateRead)
+                    .and_then(|words| write_words_to_memory(self.vm, words));
+                Poll::Ready(res)
+            }
+        }
+    }
+}
+
+/// `StateRead::WordRange` operation.
+pub fn word_range<'vm, S>(
+    state_read: &S,
+    set_addr: &ContentAddress,
+    vm: &'vm mut Vm,
+) -> OpAsyncResult<StateReadFuture<'vm, S>, S::Error>
+where
+    S: StateRead,
+{
+    let future = read_word_range(state_read, set_addr, vm)?;
+    Ok(StateReadFuture { future, vm })
+}
+
+/// `StateRead::WordRangeExtern` operation.
+pub fn word_range_ext<'vm, S>(
+    state_read: &S,
+    vm: &'vm mut Vm,
+) -> OpAsyncResult<StateReadFuture<'vm, S>, S::Error>
+where
+    S: StateRead,
+{
+    let future = read_word_range_ext(state_read, vm)?;
+    Ok(StateReadFuture { future, vm })
+}
+
+/// Read the length and key from the top of the stack and read the associated words from state.
+fn read_word_range<S>(
+    state_read: &S,
+    set_addr: &ContentAddress,
+    vm: &mut Vm,
+) -> OpAsyncResult<S::Future, S::Error>
+where
+    S: StateRead,
+{
+    let len_word = vm.stack.pop()?;
+    let len = usize::try_from(len_word).map_err(|_| StackError::IndexOutOfBounds)?;
+    let key = vm.stack.pop4()?;
+    Ok(state_read.word_range(set_addr.clone(), key, len))
+}
+
+/// Read the length, key and external set address from the top of the stack and
+/// read the associated words from state.
+fn read_word_range_ext<S>(state_read: &S, vm: &mut Vm) -> OpAsyncResult<S::Future, S::Error>
+where
+    S: StateRead,
+{
+    let len_word = vm.stack.pop()?;
+    let len = usize::try_from(len_word).map_err(|_| StackError::IndexOutOfBounds)?;
+    let key = vm.stack.pop4().map_err(OpAsyncError::from)?;
+    let set_addr = ContentAddress(u8_32_from_word_4(vm.stack.pop4()?));
+    Ok(state_read.word_range(set_addr, key, len))
+}
+
+/// Write the given words to the end of memory and push the starting memory address to the stack.
+fn write_words_to_memory<E>(vm: &mut Vm, words: Vec<Option<Word>>) -> OpAsyncResult<(), E> {
+    let start = Word::try_from(vm.memory.len()).map_err(|_| StackError::IndexOutOfBounds)?;
+    vm.memory.extend(words)?;
+    vm.stack.push(start)?;
+    Ok(())
+}

--- a/crates/state-read-vm/tests/bytecode.rs
+++ b/crates/state-read-vm/tests/bytecode.rs
@@ -1,0 +1,61 @@
+use essential_state_read_vm::{
+    asm::{self, Op},
+    BytecodeMapped,
+};
+
+// This ensures that, in the worst case where there is one operation per
+// byte (i.e. there are no `Push` operations), the size of `BytecodeMapped`
+// is still at least as or more memory efficient than a `Vec<Op>`.
+#[test]
+fn mapped_is_compact() {
+    assert!(
+        core::mem::size_of::<(u8, usize)>() <= core::mem::size_of::<Op>(),
+        "The size of a byte and its index must be smaller than or equal \
+        to a single `Op` for `BytecodeMapped` to be strictly more memory \
+        efficient than (or at least as efficient as) a `Vec<Op>`. If this \
+        test has failed and `Op` has become smaller than the size of `(u8, \
+        usize)`, then this module can be removed and `Vec<Op>` should be \
+        the preferred method of storing operations for execution."
+    );
+}
+
+// Ensure we can collect a `Result<BytecodeMapped, _>` from an iterator of `Result<Op, _>`.
+#[test]
+fn mapped_from_op_results() {
+    let results: &[Result<Op, _>] = &[
+        Ok(asm::Stack::Push(6).into()),
+        Ok(asm::Stack::Push(7).into()),
+        Ok(asm::Alu::Mul.into()),
+        Ok(asm::Stack::Push(42).into()),
+        Ok(asm::Pred::Eq.into()),
+        Ok(asm::ControlFlow::Halt.into()),
+    ];
+    let mapped: Result<BytecodeMapped, ()> = results.iter().cloned().collect();
+    mapped.unwrap();
+}
+
+#[test]
+fn mapped_from_bytes() {
+    let ops = &[
+        asm::Stack::Push(6).into(),
+        asm::Stack::Push(7).into(),
+        asm::Alu::Mul.into(),
+        asm::Stack::Push(42).into(),
+        asm::Pred::Eq.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    let bytes: Vec<_> = asm::to_bytes(ops.iter().copied()).collect();
+
+    // Ensure ops to bytecode mapped conversions behave the same.
+    let mapped_a: BytecodeMapped = asm::from_bytes(bytes.iter().copied())
+        .collect::<Result<_, _>>()
+        .unwrap();
+    let mapped_b = BytecodeMapped::try_from(bytes).unwrap();
+    assert_eq!(mapped_a, mapped_b);
+
+    // Ensure the roundtrip conversion is correct.
+    let ops_a: Vec<_> = mapped_a.ops().collect();
+    let ops_b: Vec<_> = mapped_b.ops().collect();
+    assert_eq!(ops_a, ops);
+    assert_eq!(ops_b, ops);
+}

--- a/crates/state-read-vm/tests/ctrl_flow.rs
+++ b/crates/state-read-vm/tests/ctrl_flow.rs
@@ -1,0 +1,229 @@
+mod util;
+
+use essential_state_read_vm::{
+    asm::{self, Op},
+    error::{ControlFlowError, OpSyncError},
+    error::{OpError, StateReadError},
+    GasLimit, Vm,
+};
+use util::*;
+
+#[tokio::test]
+async fn jump_forward() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(4).into(), // Jump index.
+        asm::ControlFlow::Jump.into(),
+        asm::ControlFlow::Halt.into(),
+        asm::ControlFlow::Halt.into(),
+        asm::Stack::Push(6).into(), // Jump destination.
+        asm::Stack::Push(7).into(),
+        asm::Alu::Mul.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    let spent = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_op: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await
+        .unwrap();
+    assert_eq!(spent, 6);
+    assert_eq!(&vm.stack[..], &[42]);
+}
+
+#[tokio::test]
+async fn jump_back() {
+    let mut vm = Vm::default();
+    // This program continues to loop and multiply by 2 until gas is exhausted.
+    let ops = &[
+        asm::Stack::Push(1).into(),
+        asm::Stack::Push(2).into(), // Jump destination.
+        asm::Alu::Mul.into(),
+        asm::Stack::Push(1).into(), // Jump index.
+        asm::ControlFlow::Jump.into(),
+        asm::ControlFlow::Halt.into(), // We'll never reach this.
+    ];
+    // `Jump` has no condition, so jumping back will cause looping forever.
+    // Set a gas limit to ensure that this completes.
+    // The total gas cost will be `loop_count * 4`, plus 1 for the first operation.
+    // To calculate 2^5, we want to iterate 5 times without the final jump ops:
+    // (loop_count * 4) + 1 - final_jump = (5 * 4) + 1 - 2 = 19
+    let total = 19;
+    let gas_limit = GasLimit {
+        per_yield: GasLimit::DEFAULT_PER_YIELD,
+        total,
+    };
+    let res = vm
+        .exec_ops(ops, TEST_ACCESS, &State::EMPTY, &|_op: &Op| 1, gas_limit)
+        .await;
+    let err = match res {
+        // The failing operations hould be the `Push` that follows the final
+        // multiplication, i.e. `3`.
+        Err(StateReadError::Op(3, OpError::OutOfGas(err))) => err,
+        _ => panic!("expected out of gas error, found {:?}", res),
+    };
+    assert_eq!(err.spent, total);
+    assert_eq!(err.op_gas, 1);
+    assert_eq!(err.limit, total);
+    // After 5 total iterations, the result should be 2^5.
+    assert_eq!(&vm.stack[..], &[32]);
+}
+
+#[tokio::test]
+async fn jump_if_forward() {
+    let mut vm = Vm::default();
+    let jump_dest = 10;
+    let ops = &[
+        asm::Stack::Push(6).into(),
+        asm::Stack::Push(jump_dest).into(),
+        asm::Stack::Push(0).into(),      // false
+        asm::ControlFlow::JumpIf.into(), // JumpIf should not jump.
+        asm::Stack::Push(7).into(),
+        asm::Stack::Push(jump_dest).into(),
+        asm::Stack::Push(1).into(),      // true
+        asm::ControlFlow::JumpIf.into(), // JumpIf should not jump.
+        asm::ControlFlow::Halt.into(),
+        asm::ControlFlow::Halt.into(),
+        asm::Alu::Mul.into(), // Jump destination.
+        asm::ControlFlow::Halt.into(),
+    ];
+    let spent = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_op: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await
+        .unwrap();
+    assert_eq!(spent, 10);
+    assert_eq!(&vm.stack[..], &[42]);
+}
+
+#[tokio::test]
+async fn jump_if_back() {
+    let mut vm = Vm::default();
+    // Find the nth power of 2 by looping using JumpIf.
+    let nth_power = 8;
+    let jump_dest = 2;
+    let ops = &[
+        // Setup the loop counter and the value carrying the power of 2.
+        asm::Stack::Push(0).into(), // [counter]
+        asm::Stack::Push(1).into(), // [counter, value]
+        // Multiply value by 2.
+        asm::Stack::Push(2).into(), // [counter, value, 2] JUMP DESTINATION
+        asm::Alu::Mul.into(),       // [counter, value*2]
+        // Increment the counter by 1.
+        asm::Stack::Swap.into(),    // [value, counter]
+        asm::Stack::Push(1).into(), // [value, counter, 1]
+        asm::Alu::Add.into(),       // [value, counter+1]
+        // Jump back if the counter is less than `nth_power`.
+        asm::Stack::Swap.into(),            // [counter, value]
+        asm::Stack::Push(1).into(),         // [counter, value, 1]
+        asm::Stack::DupFrom.into(),         // [counter, value, counter]
+        asm::Stack::Push(nth_power).into(), // [counter, value, counter, nth_power]
+        asm::Pred::Lt.into(),               // [counter, value, cond]
+        asm::Stack::Push(jump_dest).into(), // [counter, value, cond, jump_dest]
+        asm::Stack::Swap.into(),            // [counter, value, jump_dest, cond]
+        asm::ControlFlow::JumpIf.into(),    // [counter, value] JUMP BACK
+        // Pop the counter so that we're left with the value.
+        asm::Stack::Swap.into(), // [value, counter]
+        asm::Stack::Pop.into(),  // [value]
+        asm::ControlFlow::Halt.into(),
+    ];
+    let spent = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_op: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await
+        .unwrap();
+    // After 5 total iterations, the result should be 2^5.
+    assert_eq!(
+        spent,
+        2 /*setup*/ + 13 * nth_power as u64 /*loop*/ + 3 /*cleanup*/
+    );
+    assert_eq!(&vm.stack[..], &[2i64.pow(nth_power as u32)]);
+}
+
+#[tokio::test]
+async fn jump_if_invalid_cond() {
+    let mut vm = Vm::default();
+    let invalid_cond = 2; // Valid is 0 or 1.
+    let ops = &[
+        asm::Stack::Push(0).into(), // Destination Index.
+        asm::Stack::Push(invalid_cond).into(),
+        asm::ControlFlow::JumpIf.into(),
+    ];
+    let res = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await;
+    match res {
+        Err(StateReadError::Op(
+            _,
+            OpError::Sync(OpSyncError::ControlFlow(ControlFlowError::InvalidJumpIfCondition(n))),
+        )) if n == invalid_cond => (),
+        _ => panic!("expected overflow, found {:?}", res),
+    }
+}
+
+#[tokio::test]
+async fn missing_halt() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(6).into(),
+        asm::Stack::Push(7).into(),
+        asm::Alu::Mul.into(),
+    ];
+    let res = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await;
+    match res {
+        Err(StateReadError::PcOutOfRange(pc)) if pc == ops.len() => (),
+        _ => panic!("expected overflow, found {:?}", res),
+    }
+}
+
+#[tokio::test]
+async fn jump_pc_out_of_range() {
+    let mut vm = Vm::default();
+    let pc_out_of_range = 3;
+    let ops = &[
+        asm::Stack::Push(pc_out_of_range).into(),
+        asm::ControlFlow::Jump.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    let res = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await;
+    match res {
+        Err(StateReadError::PcOutOfRange(pc)) if pc == pc_out_of_range as usize => (),
+        _ => panic!("expected overflow, found {:?}", res),
+    }
+}

--- a/crates/state-read-vm/tests/memory.rs
+++ b/crates/state-read-vm/tests/memory.rs
@@ -1,0 +1,454 @@
+mod util;
+
+use essential_state_read_vm::{
+    asm::{self, Op, Word},
+    error::{MemoryError, OpError, OpSyncError, StateReadError},
+    GasLimit, Memory, Vm,
+};
+use util::*;
+
+#[tokio::test]
+async fn alloc() {
+    let mut vm = Vm::default();
+    let cap = 5;
+    assert_eq!(vm.memory.capacity(), 0);
+    let ops = &[
+        asm::Stack::Push(cap).into(),
+        asm::Memory::Alloc.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    assert_eq!(vm.memory.capacity(), cap as usize);
+}
+
+#[tokio::test]
+async fn capacity() {
+    let mut vm = Vm::default();
+    let cap = 3;
+    assert_eq!(vm.memory.capacity(), 0);
+    let ops = &[
+        asm::Stack::Push(cap).into(),
+        asm::Memory::Alloc.into(),
+        asm::Memory::Capacity.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    assert_eq!(vm.memory.capacity(), cap as usize);
+    assert_eq!(&vm.stack[..], &[cap]);
+}
+
+#[tokio::test]
+async fn clear() {
+    let mut vm = Vm::default();
+    // First, push a value.
+    let ops = &[
+        asm::Stack::Push(1).into(),
+        asm::Memory::Alloc.into(),
+        asm::Stack::Push(42).into(),
+        asm::Memory::Push.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    assert_eq!(vm.memory.capacity(), 1);
+    assert_eq!(&vm.memory[..], &[Some(42)]);
+    // Next, clear the value.
+    let ops = &[
+        asm::Stack::Push(0).into(),
+        asm::Memory::Clear.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.pc = 0;
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    // Capacity remains the same. But the value is `None`.
+    assert_eq!(vm.memory.capacity(), 1);
+    assert_eq!(&vm.memory[..], &[None]);
+}
+
+#[tokio::test]
+async fn clear_range() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(4).into(),
+        asm::Memory::Alloc.into(),
+        asm::Stack::Push(42).into(),
+        asm::Memory::Push.into(),
+        asm::Stack::Push(42).into(),
+        asm::Memory::Push.into(),
+        asm::Stack::Push(42).into(),
+        asm::Memory::Push.into(),
+        asm::Stack::Push(42).into(),
+        asm::Memory::Push.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    assert_eq!(vm.memory.capacity(), 4);
+    assert_eq!(&vm.memory[..], &[Some(42), Some(42), Some(42), Some(42)]);
+    // Next, clear the values at indices 1 and 2.
+    let ops = &[
+        asm::Stack::Push(1).into(),
+        asm::Stack::Push(2).into(),
+        asm::Memory::ClearRange.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.pc = 0;
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    // Capacity remains the same, but middle values should be None.
+    assert_eq!(vm.memory.capacity(), 4);
+    assert_eq!(&vm.memory[..], &[Some(42), None, None, Some(42)]);
+    assert!(vm.stack.is_empty());
+}
+
+#[tokio::test]
+async fn free() {
+    let mut vm = Vm::default();
+    let size = 3;
+    assert_eq!(vm.memory.capacity(), 0);
+    let ops = &[
+        asm::Stack::Push(size).into(),
+        asm::Memory::Alloc.into(),
+        asm::Stack::Push(size).into(),
+        asm::Memory::Free.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    assert_eq!(vm.memory.capacity(), 0);
+}
+
+#[tokio::test]
+async fn is_some() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(1).into(),
+        asm::Memory::Alloc.into(),
+        asm::Stack::Push(42).into(),
+        asm::Memory::Push.into(),
+        asm::Stack::Push(0).into(), // Check if the value at index 0 is `Some`
+        asm::Memory::IsSome.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    assert_eq!(&vm.stack[..], &[1 /*true*/],);
+}
+
+#[tokio::test]
+async fn length() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(6).into(),
+        asm::Memory::Alloc.into(),
+        asm::Stack::Push(42).into(),
+        asm::Memory::Push.into(),
+        asm::Stack::Push(42).into(),
+        asm::Memory::Push.into(),
+        asm::Stack::Push(42).into(),
+        asm::Memory::Push.into(),
+        asm::Memory::Length.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    // Make sure that capacity and length are tracked separately correctly.
+    assert_eq!(vm.memory.capacity(), 6);
+    assert_eq!(vm.memory.len(), 3);
+    assert_eq!(&vm.stack[..], &[3]);
+}
+
+#[tokio::test]
+async fn load() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(1).into(),
+        asm::Memory::Alloc.into(),
+        asm::Stack::Push(42).into(),
+        asm::Memory::Push.into(),
+        asm::Stack::Push(0).into(), // Load the value at index 0
+        asm::Memory::Load.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    assert_eq!(&vm.memory[..], &[Some(42)]);
+    assert_eq!(&vm.stack[..], &[42]);
+}
+
+#[tokio::test]
+async fn push() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(1).into(),
+        asm::Memory::Alloc.into(),
+        asm::Stack::Push(42).into(),
+        asm::Memory::Push.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    assert_eq!(vm.memory.capacity(), 1);
+    assert_eq!(&vm.memory[..], &[Some(42)]);
+    assert!(vm.stack.is_empty());
+}
+
+#[tokio::test]
+async fn push_none() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(2).into(),
+        asm::Memory::Alloc.into(),
+        asm::Memory::PushNone.into(),
+        asm::Memory::PushNone.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    assert_eq!(vm.memory.capacity(), 2);
+    assert_eq!(&vm.memory[..], &[None, None]);
+    assert!(vm.stack.is_empty());
+}
+
+#[tokio::test]
+async fn store() {
+    let mut vm = Vm::default();
+    let ops = &[
+        // Allocate two slots.
+        asm::Stack::Push(2).into(),
+        asm::Memory::Alloc.into(),
+        // Push two `None`s onto the allocated memory.
+        asm::Memory::PushNone.into(),
+        asm::Memory::PushNone.into(),
+        // Store `Some(42)` in the second slot.
+        asm::Stack::Push(1).into(),
+        asm::Stack::Push(42).into(),
+        asm::Memory::Store.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    assert_eq!(&vm.memory[..], &[None, Some(42)]);
+}
+
+#[tokio::test]
+async fn truncate() {
+    let mut vm = Vm::default();
+    let ops = &[
+        // Push 3 `None`s.
+        asm::Stack::Push(3).into(),
+        asm::Memory::Alloc.into(),
+        asm::Memory::PushNone.into(),
+        asm::Memory::PushNone.into(),
+        asm::Memory::PushNone.into(),
+        // Truncate down to one `None`. Doesn't affect capacity.
+        asm::Stack::Push(1).into(),
+        asm::Memory::Truncate.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(
+        ops,
+        TEST_ACCESS,
+        &State::EMPTY,
+        &|_: &Op| 1,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    assert_eq!(&vm.memory[..], &[None]);
+    assert_eq!(vm.memory.capacity(), 3);
+}
+
+#[tokio::test]
+async fn load_index_oob() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(0).into(),
+        asm::Memory::Load.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    let res = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await;
+    match res {
+        Err(StateReadError::Op(
+            _,
+            OpError::Sync(OpSyncError::Memory(MemoryError::IndexOutOfBounds)),
+        )) => (),
+        _ => panic!("expected index out of bounds, found {:?}", res),
+    }
+}
+
+#[tokio::test]
+async fn store_index_oob() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(0).into(),
+        asm::Stack::Push(0).into(),
+        asm::Memory::Store.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    let res = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await;
+    match res {
+        Err(StateReadError::Op(
+            _,
+            OpError::Sync(OpSyncError::Memory(MemoryError::IndexOutOfBounds)),
+        )) => (),
+        _ => panic!("expected index out of bounds, found {:?}", res),
+    }
+}
+
+#[tokio::test]
+async fn push_overflow() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(42).into(),
+        asm::Memory::Push.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    let res = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await;
+    match res {
+        Err(StateReadError::Op(_, OpError::Sync(OpSyncError::Memory(MemoryError::Overflow)))) => (),
+        _ => panic!("expected overflow, found {:?}", res),
+    }
+}
+
+#[tokio::test]
+async fn alloc_overflow() {
+    let mut vm = Vm::default();
+    let overflow_cap = Word::try_from(Memory::SIZE_LIMIT.checked_add(1).unwrap()).unwrap();
+    let ops = &[
+        asm::Stack::Push(overflow_cap).into(),
+        asm::Memory::Alloc.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    let res = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await;
+    match res {
+        Err(StateReadError::Op(_, OpError::Sync(OpSyncError::Memory(MemoryError::Overflow)))) => (),
+        _ => panic!("expected overflow, found {:?}", res),
+    }
+}

--- a/crates/state-read-vm/tests/state_read.rs
+++ b/crates/state-read-vm/tests/state_read.rs
@@ -1,0 +1,123 @@
+mod util;
+
+use essential_state_read_vm::{
+    asm::{self, Op},
+    types::{convert::word_4_from_u8_32, ContentAddress},
+    GasLimit, Vm,
+};
+use util::*;
+
+#[tokio::test]
+async fn state_read_3_42s() {
+    let access = TEST_ACCESS;
+    let state = State::new(vec![(
+        access.solution.this_data().intent_to_solve.set.clone(),
+        vec![([0, 0, 0, 0], 42), ([0, 0, 0, 1], 42), ([0, 0, 0, 2], 42)],
+    )]);
+    let mut vm = Vm::default();
+    let num_words = 3;
+    let ops = &[
+        asm::Stack::Push(num_words).into(),
+        asm::Memory::Alloc.into(),
+        asm::Stack::Push(0).into(), // Key0
+        asm::Stack::Push(0).into(), // Key1
+        asm::Stack::Push(0).into(), // Key2
+        asm::Stack::Push(0).into(), // Key3
+        asm::Stack::Push(num_words).into(),
+        asm::StateRead::WordRange,
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(ops, access, &state, &|_: &Op| 1, GasLimit::UNLIMITED)
+        .await
+        .unwrap();
+    assert_eq!(&vm.memory[..], &[Some(42), Some(42), Some(42)]);
+    assert_eq!(vm.memory.capacity(), 3);
+}
+
+#[tokio::test]
+async fn state_read_some_none_some() {
+    let access = TEST_ACCESS;
+    let state = State::new(vec![(
+        access.solution.this_data().intent_to_solve.set.clone(),
+        vec![([0, 0, 0, 0], 42), ([0, 0, 0, 2], 42)],
+    )]);
+    let mut vm = Vm::default();
+    let num_words = 3;
+    let ops = &[
+        asm::Stack::Push(num_words).into(),
+        asm::Memory::Alloc.into(),
+        asm::Stack::Push(0).into(), // Key0
+        asm::Stack::Push(0).into(), // Key1
+        asm::Stack::Push(0).into(), // Key2
+        asm::Stack::Push(0).into(), // Key3
+        asm::Stack::Push(num_words).into(),
+        asm::StateRead::WordRange,
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(ops, access, &state, &|_: &Op| 1, GasLimit::UNLIMITED)
+        .await
+        .unwrap();
+    assert_eq!(&vm.memory[..], &[Some(42), None, Some(42)]);
+    assert_eq!(vm.memory.capacity(), 3);
+}
+
+#[tokio::test]
+async fn state_read_ext() {
+    let ext_set_addr = ContentAddress([0x12; 32]);
+    let state = State::new(vec![(
+        ext_set_addr.clone(),
+        vec![([1, 2, 3, 4], 40), ([1, 2, 3, 5], 41), ([1, 2, 3, 6], 42)],
+    )]);
+    let mut vm = Vm::default();
+    let num_words = 3;
+    let [addr0, addr1, addr2, addr3] = word_4_from_u8_32(ext_set_addr.0);
+    let ops = &[
+        asm::Stack::Push(num_words).into(),
+        asm::Memory::Alloc.into(),
+        asm::Stack::Push(addr0).into(),
+        asm::Stack::Push(addr1).into(),
+        asm::Stack::Push(addr2).into(),
+        asm::Stack::Push(addr3).into(),
+        asm::Stack::Push(1).into(), // Key0
+        asm::Stack::Push(2).into(), // Key1
+        asm::Stack::Push(3).into(), // Key2
+        asm::Stack::Push(4).into(), // Key3
+        asm::Stack::Push(num_words).into(),
+        asm::StateRead::WordRangeExtern,
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(ops, TEST_ACCESS, &state, &|_: &Op| 1, GasLimit::UNLIMITED)
+        .await
+        .unwrap();
+    assert_eq!(&vm.memory[..], &[Some(40), Some(41), Some(42)]);
+    assert_eq!(vm.memory.capacity(), 3);
+}
+
+#[tokio::test]
+async fn state_read_ext_nones() {
+    let ext_set_addr = ContentAddress([0x12; 32]);
+    let state = State::new(vec![(ext_set_addr.clone(), vec![])]);
+    let mut vm = Vm::default();
+    let num_words = 3;
+    let [addr0, addr1, addr2, addr3] = word_4_from_u8_32(ext_set_addr.0);
+    let ops = &[
+        asm::Stack::Push(num_words).into(),
+        asm::Memory::Alloc.into(),
+        asm::Stack::Push(addr0).into(),
+        asm::Stack::Push(addr1).into(),
+        asm::Stack::Push(addr2).into(),
+        asm::Stack::Push(addr3).into(),
+        asm::Stack::Push(1).into(), // Key0
+        asm::Stack::Push(2).into(), // Key1
+        asm::Stack::Push(3).into(), // Key2
+        asm::Stack::Push(4).into(), // Key3
+        asm::Stack::Push(num_words).into(),
+        asm::StateRead::WordRangeExtern,
+        asm::ControlFlow::Halt.into(),
+    ];
+    vm.exec_ops(ops, TEST_ACCESS, &state, &|_: &Op| 1, GasLimit::UNLIMITED)
+        .await
+        .unwrap();
+    assert_eq!(&vm.memory[..], &[None, None, None]);
+    assert_eq!(vm.memory.capacity(), 3);
+}

--- a/crates/state-read-vm/tests/util.rs
+++ b/crates/state-read-vm/tests/util.rs
@@ -1,0 +1,120 @@
+// Cargo treats each test in `tests` as a crate, so for some tests some items
+// are considered dead code.
+#![allow(dead_code)]
+
+use essential_state_read_vm::{
+    types::{solution::SolutionData, ContentAddress, IntentAddress, Key, Word},
+    Access, SolutionAccess, StateRead, StateSlots,
+};
+use std::{
+    collections::BTreeMap,
+    future::{self, Ready},
+};
+use thiserror::Error;
+
+pub const TEST_SET_CA: ContentAddress = ContentAddress([0xFF; 32]);
+pub const TEST_INTENT_CA: ContentAddress = ContentAddress([0xAA; 32]);
+pub const TEST_INTENT_ADDR: IntentAddress = IntentAddress {
+    set: TEST_SET_CA,
+    intent: TEST_INTENT_CA,
+};
+pub const TEST_SOLUTION_DATA: SolutionData = SolutionData {
+    intent_to_solve: TEST_INTENT_ADDR,
+    decision_variables: vec![],
+};
+pub const TEST_SOLUTION_ACCESS: SolutionAccess = SolutionAccess {
+    data: &[TEST_SOLUTION_DATA],
+    index: 0,
+};
+pub const TEST_ACCESS: Access = Access {
+    solution: TEST_SOLUTION_ACCESS,
+    state_slots: StateSlots::EMPTY,
+};
+
+// A test `StateRead` implementation represented using a map.
+#[derive(Clone)]
+pub struct State(BTreeMap<ContentAddress, BTreeMap<Key, Word>>);
+
+#[derive(Debug, Error)]
+#[error("no value for the given intent set, key pair")]
+pub struct InvalidStateRead;
+
+impl State {
+    // Empry state, fine for tests unrelated to reading state.
+    pub const EMPTY: Self = State(BTreeMap::new());
+
+    // Shorthand test state constructor.
+    pub fn new(sets: Vec<(ContentAddress, Vec<(Key, Word)>)>) -> Self {
+        State(
+            sets.into_iter()
+                .map(|(addr, vec)| {
+                    let map: BTreeMap<_, _> = vec.into_iter().collect();
+                    (addr, map)
+                })
+                .collect(),
+        )
+    }
+
+    // Update the value at the given key within the given intent set address.
+    pub fn set(&mut self, set_addr: ContentAddress, key: &Key, value: Option<Word>) {
+        let set = self.0.entry(set_addr).or_default();
+        match value {
+            None => {
+                set.remove(key);
+            }
+            Some(value) => {
+                set.insert(*key, value);
+            }
+        }
+    }
+
+    /// Retrieve a word range.
+    pub fn word_range(
+        &self,
+        set_addr: ContentAddress,
+        mut key: Key,
+        num_words: usize,
+    ) -> Result<Vec<Option<Word>>, InvalidStateRead> {
+        // Get the key that follows this one.
+        fn next_key(mut key: Key) -> Option<Key> {
+            for w in key.iter_mut().rev() {
+                match *w {
+                    Word::MAX => *w = Word::MIN,
+                    _ => {
+                        *w += 1;
+                        return Some(key);
+                    }
+                }
+            }
+            None
+        }
+
+        // Collect the words.
+        let mut words = vec![];
+        for _ in 0..num_words {
+            let opt = self
+                .get(&set_addr)
+                .ok_or(InvalidStateRead)?
+                .get(&key)
+                .cloned();
+            words.push(opt);
+            key = next_key(key).ok_or(InvalidStateRead)?;
+        }
+        Ok(words)
+    }
+}
+
+impl core::ops::Deref for State {
+    type Target = BTreeMap<ContentAddress, BTreeMap<Key, Word>>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl StateRead for State {
+    type Error = InvalidStateRead;
+    type Future = Ready<Result<Vec<Option<Word>>, Self::Error>>;
+    fn word_range(&self, set_addr: ContentAddress, key: Key, num_words: usize) -> Self::Future {
+        future::ready(self.word_range(set_addr, key, num_words))
+    }
+}

--- a/crates/state-read-vm/tests/vm.rs
+++ b/crates/state-read-vm/tests/vm.rs
@@ -1,0 +1,307 @@
+//! Top-level testing of the VM.
+
+mod util;
+
+use essential_state_read_vm::{
+    asm::{self, Op},
+    constraint,
+    types::solution::{Mutation, Solution, SolutionData, StateMutation},
+    Access, BytecodeMapped, Gas, GasLimit, SolutionAccess, StateSlots, Vm,
+};
+use util::*;
+
+// A simple sanity test to check basic functionality.
+#[tokio::test]
+async fn no_yield() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(6).into(),
+        asm::Stack::Push(7).into(),
+        asm::Alu::Mul.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    let op_gas_cost = &|_: &Op| 1;
+    let spent = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            op_gas_cost,
+            GasLimit::UNLIMITED,
+        )
+        .await
+        .unwrap();
+    assert_eq!(spent, ops.iter().map(op_gas_cost).sum::<Gas>());
+    assert_eq!(vm.pc, ops.len() - 1);
+    assert_eq!(&vm.stack[..], &[42]);
+}
+
+// Test that we get expected results when yielding due to gas limits.
+#[tokio::test]
+async fn yield_per_op() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(6).into(),
+        asm::Stack::Push(7).into(),
+        asm::Alu::Mul.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    // Force the VM to yield after every op to test behaviour.
+    let op_gas_cost = |_op: &_| GasLimit::DEFAULT_PER_YIELD;
+
+    let state = State::EMPTY;
+    let mut future = vm.exec_ops(ops, TEST_ACCESS, &state, &op_gas_cost, GasLimit::UNLIMITED);
+
+    // Test that we yield once per op before reaching `Halt`.
+    let mut yield_count = 0;
+    let spent = {
+        let mut future = std::pin::pin!(future);
+        loop {
+            match futures::poll!(&mut future) {
+                std::task::Poll::Pending => yield_count += 1,
+                std::task::Poll::Ready(res) => break res.unwrap(),
+            }
+        }
+    };
+
+    assert_eq!(yield_count, ops.len() - 1);
+    assert_eq!(spent, ops.iter().map(op_gas_cost).sum::<Gas>());
+    assert_eq!(vm.pc, ops.len() - 1);
+    assert_eq!(&vm.stack[..], &[42]);
+}
+
+// Test VM behaves as expected when continuing execution over more operations.
+#[tokio::test]
+async fn continue_execution() {
+    let mut vm = Vm::default();
+
+    // Execute first set of ops.
+    let ops = &[
+        asm::Stack::Push(6).into(),
+        asm::Stack::Push(7).into(),
+        asm::Alu::Mul.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    let op_gas_cost = &|_: &Op| 1;
+    let spent = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            op_gas_cost,
+            GasLimit::UNLIMITED,
+        )
+        .await
+        .unwrap();
+    assert_eq!(spent, ops.iter().map(op_gas_cost).sum::<Gas>());
+    assert_eq!(vm.pc, ops.len() - 1);
+    assert_eq!(&vm.stack[..], &[42]);
+
+    // Continue executing from current state over the new ops.
+    vm.pc = 0;
+    let ops = &[
+        asm::Stack::Push(6).into(),
+        asm::Alu::Div.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+    let spent = vm
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &op_gas_cost,
+            GasLimit::UNLIMITED,
+        )
+        .await
+        .unwrap();
+    assert_eq!(spent, ops.iter().map(op_gas_cost).sum::<Gas>());
+    assert_eq!(vm.pc, ops.len() - 1);
+    assert_eq!(&vm.stack[..], &[7]);
+}
+
+// Ensure basic programs evaluate to the same thing
+#[tokio::test]
+async fn exec_method_behaviours_match() {
+    // The operations of the test program.
+    let ops: &[Op] = &[
+        asm::Stack::Push(6).into(),
+        asm::Stack::Push(7).into(),
+        asm::Alu::Mul.into(),
+        asm::ControlFlow::Halt.into(),
+    ];
+
+    // Execute the ops using `exec_ops`.
+    let mut vm_ops = Vm::default();
+    let spent_ops = vm_ops
+        .exec_ops(
+            ops,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await
+        .unwrap();
+
+    // Execute the same ops but as mapped bytecode.
+    let mapped: BytecodeMapped = ops.iter().copied().collect();
+    let mut vm_bc = Vm::default();
+    let spent_bc = vm_bc
+        .exec_bytecode(
+            &mapped,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await
+        .unwrap();
+    assert_eq!(spent_ops, spent_bc);
+    assert_eq!(vm_ops, vm_bc);
+
+    // Execute the same ops, but from a bytes iterator.
+    let bc_iter = mapped.bytecode().iter().copied();
+    let mut vm_bc_iter = Vm::default();
+    let spent_bc_iter = vm_bc_iter
+        .exec_bytecode_iter(
+            bc_iter,
+            TEST_ACCESS,
+            &State::EMPTY,
+            &|_: &Op| 1,
+            GasLimit::UNLIMITED,
+        )
+        .await
+        .unwrap();
+    assert_eq!(spent_ops, spent_bc_iter);
+    assert_eq!(vm_ops, vm_bc_iter);
+}
+
+// Emulate the process of reading pre state, applying mutations to produce
+// post state, and checking the constraints afterwards.
+#[tokio::test]
+async fn read_pre_post_state_and_check_constraints() {
+    let intent_addr = TEST_INTENT_ADDR;
+
+    // In the pre-state, we have [Some(40), None, Some(42)].
+    let pre_state = State::new(vec![(
+        intent_addr.set.clone(),
+        vec![([0, 0, 0, 0], 40), ([0, 0, 0, 2], 42)],
+    )]);
+
+    // The full solution that we're checking.
+    let solution = Solution {
+        data: vec![SolutionData {
+            intent_to_solve: intent_addr.clone(),
+            decision_variables: vec![],
+        }],
+        // We have one mutation that sets a missing value to 41.
+        state_mutations: vec![StateMutation {
+            pathway: 0,
+            mutations: vec![Mutation {
+                key: [0, 0, 0, 1],
+                value: Some(41),
+            }],
+        }],
+        partial_solutions: vec![],
+    };
+
+    // Construct access to the necessary solution data for the VM.
+    let mut access = Access {
+        solution: SolutionAccess {
+            data: &solution.data,
+            index: 0,
+        },
+        // Haven't calculated these yet.
+        state_slots: StateSlots::EMPTY,
+    };
+
+    // A simple state read program that reads words directly to the slots.
+    let ops = &[
+        asm::Stack::Push(3).into(),
+        asm::Memory::Alloc.into(),
+        asm::Stack::Push(0).into(), // Key0
+        asm::Stack::Push(0).into(), // Key1
+        asm::Stack::Push(0).into(), // Key2
+        asm::Stack::Push(0).into(), // Key3
+        asm::Stack::Push(3).into(), // Num words
+        asm::StateRead::WordRange,
+        asm::ControlFlow::Halt.into(),
+    ];
+
+    // Execute the program.
+    let mut vm = Vm::default();
+    vm.exec_ops(ops, access, &pre_state, &|_: &Op| 1, GasLimit::UNLIMITED)
+        .await
+        .unwrap();
+
+    // Collect the state slots.
+    let pre_state_slots = vm.into_state_slots();
+
+    // Apply the state mutations to the state to produce the post state.
+    let mut post_state = pre_state.clone();
+    for mutation in solution.state_mutations {
+        let solution_data = &solution.data[usize::from(mutation.pathway)];
+        let set_addr = &solution_data.intent_to_solve.set;
+        for Mutation { key, value } in mutation.mutations.iter() {
+            post_state.set(set_addr.clone(), key, *value);
+        }
+    }
+
+    // Execute the program with the post state.
+    let mut vm = Vm::default();
+    vm.exec_ops(ops, access, &post_state, &|_: &Op| 1, GasLimit::UNLIMITED)
+        .await
+        .unwrap();
+
+    // Collect the state slots.
+    let post_state_slots = vm.into_state_slots();
+
+    // State slots should have updated.
+    assert_eq!(&pre_state_slots[..], &[Some(40), None, Some(42)]);
+    assert_eq!(&post_state_slots[..], &[Some(40), Some(41), Some(42)]);
+
+    // Now, they can be used for constraint checking.
+    access.state_slots = StateSlots {
+        pre: &pre_state_slots[..],
+        post: &post_state_slots[..],
+    };
+    let constraints: &[Vec<u8>] = &[
+        // Check that the first pre and post slots are equal.
+        constraint::asm::to_bytes(vec![
+            asm::Stack::Push(0).into(), // slot
+            asm::Stack::Push(0).into(), // pre
+            asm::Access::State.into(),
+            asm::Stack::Push(0).into(), // slot
+            asm::Stack::Push(1).into(), // post
+            asm::Access::State.into(),
+            asm::Pred::Eq.into(),
+        ])
+        .collect(),
+        // Check that the second pre state is none, but post is some.
+        constraint::asm::to_bytes(vec![
+            asm::Stack::Push(1).into(), // slot
+            asm::Stack::Push(0).into(), // pre
+            asm::Access::StateIsSome.into(),
+            asm::Pred::Not.into(),
+            asm::Stack::Push(1).into(), // slot
+            asm::Stack::Push(1).into(), // post
+            asm::Access::StateIsSome.into(),
+            asm::Pred::And.into(),
+        ])
+        .collect(),
+        // Check that the third pre and post slots are equal.
+        constraint::asm::to_bytes(vec![
+            asm::Stack::Push(2).into(), // slot
+            asm::Stack::Push(0).into(), // pre
+            asm::Access::State.into(),
+            asm::Stack::Push(2).into(), // slot
+            asm::Stack::Push(1).into(), // post
+            asm::Access::State.into(),
+            asm::Pred::Eq.into(),
+        ])
+        .collect(),
+    ];
+    constraint::check_intent(constraints, access).unwrap();
+
+    // Constraints pass - we're free to apply the updated state!
+}


### PR DESCRIPTION
This upstreams the crates verbatim without any behavioural changes.

**Related**
- essential-contributions/essential-server#68
    - previously mentioned in essential-contributions/essential-server#61).