### PR TITLE
feat: Make `BytecodeMapped` generic over its `bytecode` slice type

### DIFF
--- a/crates/constraint-vm/src/op_access.rs
+++ b/crates/constraint-vm/src/op_access.rs
@@ -32,9 +32,10 @@ where
     }
 }
 
-impl<'a, Op> OpAccess for &'a BytecodeMapped<Op>
+impl<'a, Op, Bytes> OpAccess for &'a BytecodeMapped<Op, Bytes>
 where
     Op: TryFromBytes,
+    Bytes: core::ops::Deref<Target = [u8]>,
 {
     type Op = Op;
     type Error = core::convert::Infallible;

--- a/crates/state-read-vm/src/lib.rs
+++ b/crates/state-read-vm/src/lib.rs
@@ -66,7 +66,7 @@ pub struct Vm {
 pub type Gas = u64;
 
 /// Shorthand for the `BytecodeMapped` type representing a mapping to/from state read [`Op`]s.
-pub type BytecodeMapped = constraint::BytecodeMapped<Op>;
+pub type BytecodeMapped<Bytes = Vec<u8>> = constraint::BytecodeMapped<Op, Bytes>;
 /// Shorthand for the `BytecodeMappedSlice` type for mapping [`Op`]s.
 pub type BytecodeMappedSlice<'a> = constraint::BytecodeMappedSlice<'a, Op>;
 /// Shorthand for the `BytecodeMappedLazy` type for mapping [`Op`]s.
@@ -169,9 +169,9 @@ impl Vm {
     /// This can be a more memory efficient alternative to [`Vm::exec_ops`] due
     /// to the compact representation of operations in the form of bytecode and
     /// indices.
-    pub async fn exec_bytecode<'a, S>(
+    pub async fn exec_bytecode<'a, S, B>(
         &mut self,
-        bytecode_mapped: &BytecodeMapped,
+        bytecode_mapped: &BytecodeMapped<B>,
         access: Access<'a>,
         state_read: &S,
         op_gas_cost: &impl OpGasCost,
@@ -179,6 +179,7 @@ impl Vm {
     ) -> Result<Gas, StateReadError<S::Error>>
     where
         S: StateRead,
+        B: core::ops::Deref<Target = [u8]>,
     {
         self.exec(access, state_read, bytecode_mapped, op_gas_cost, gas_limit)
             .await

--- a/crates/state-read-vm/tests/bytecode.rs
+++ b/crates/state-read-vm/tests/bytecode.rs
@@ -50,12 +50,18 @@ fn mapped_from_bytes() {
     let mapped_a: BytecodeMapped = asm::from_bytes(bytes.iter().copied())
         .collect::<Result<_, _>>()
         .unwrap();
-    let mapped_b = BytecodeMapped::try_from(bytes).unwrap();
+    // Check mapping of `Vec<u8>`.
+    let mapped_b = BytecodeMapped::try_from(bytes.clone()).unwrap();
     assert_eq!(mapped_a, mapped_b);
+    // Check mapping of `&[u8]`.
+    let mapped_c = BytecodeMapped::try_from(&bytes[..]).unwrap();
+    assert_eq!(mapped_a.as_slice(), mapped_c.as_slice());
 
     // Ensure the roundtrip conversion is correct.
     let ops_a: Vec<_> = mapped_a.ops().collect();
     let ops_b: Vec<_> = mapped_b.ops().collect();
+    let ops_c: Vec<_> = mapped_c.ops().collect();
     assert_eq!(ops_a, ops);
     assert_eq!(ops_b, ops);
+    assert_eq!(ops_c, ops);
 }


### PR DESCRIPTION
Previously, `BytecodeMapped` could either:

- Consume and map an owned `Vec<u8>`.
- Construct the inner `bytecode` `Vec<u8>` lazily as operations are pushed to it.

This PR adds a third option which is to borrow and map an existing slice of bytes by making the inner `bytecode` type generic. This allows for constructing `BytecodeMapped` around a `&[u8]`, `Arc<[u8]>`, or any other types that derefence to a slice of bytes.

This should help us to avoid the need to use `exec_bytecode_iter` downstream in the essential server as seen here:

https://github.com/essential-contributions/essential-server/blob/80be250cc413df70f301c34570ce66a682f9e40a/crates/essential/src/solution.rs#L299-L305

Instead, we can use `exec_bytecode` and make use of the existing slice.

Closes #64.