### PR TITLE
feat: Introduce a minimal `essential-hash` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +63,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +79,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "const-oid"
@@ -79,6 +100,12 @@ checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-deque"
@@ -200,6 +227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +277,17 @@ dependencies = [
  "rayon",
  "sha2",
  "thiserror",
+]
+
+[[package]]
+name = "essential-hash"
+version = "0.1.0"
+dependencies = [
+ "essential-types",
+ "hex",
+ "postcard",
+ "serde",
+ "sha2",
 ]
 
 [[package]]
@@ -399,10 +443,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "indexmap"
@@ -425,6 +498,16 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "memchr"
@@ -477,6 +560,18 @@ name = "platforms"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
+
+[[package]]
+name = "postcard"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+dependencies = [
+ "cobs",
+ "embedded-io",
+ "heapless",
+ "serde",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -598,6 +693,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +789,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +806,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ essential-state-read-vm = { path = "crates/state-read-vm" }
 essential-types = { path = "crates/types" }
 futures = "0.3" # For `state-read-vm` tests.
 hex = "0.4.3"
+postcard = { version = "1.0.8", default-featues = false, features = ["alloc"] }
 proc-macro2 = "1"
 quote = "1"
 rand = { version = "0.8", features = ["small_rng"] } # For VM tests.

--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "essential-hash"
+description = "A minimal crate containing Essential's hash method and associated pre-hash serialization implementation."
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+essential-types = { workspace = true }
+postcard = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+
+[dev-dependencies]
+hex = { workspace = true }

--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -1,0 +1,29 @@
+//! A minimal crate containing Essential's [`hash`] function and associated pre-hash
+//! generic serialization implementation [`serialize`] based on [`postcard`].
+
+#![deny(missing_docs)]
+#![deny(unsafe_code)]
+
+use essential_types::Hash;
+use serde::Serialize;
+use sha2::Digest;
+
+/// Serialize data for hashing using postcard.
+///
+/// This serialization format is standardized across essential crates.
+/// Attempting to hash data serialized with any other serialization
+/// implementation will almost certainly result in a different hash.
+pub fn serialize<T: Serialize>(t: &T) -> Vec<u8> {
+    postcard::to_allocvec(t).expect("`postcard`'s `Serializer` implementation should never fail")
+}
+
+/// Hash data using SHA-256.
+///
+/// Internally, this first serializes the given type using [`serialize`] then
+/// hashes the resulting slice of bytes using the `Sha256` digest.
+pub fn hash<T: Serialize>(t: &T) -> Hash {
+    let data = serialize(t);
+    let mut hasher = <sha2::Sha256 as sha2::Digest>::new();
+    hasher.update(&data);
+    hasher.finalize().into()
+}

--- a/crates/hash/tests/hash.rs
+++ b/crates/hash/tests/hash.rs
@@ -1,0 +1,32 @@
+use essential_types::{
+    intent::{Directive, Intent},
+    slots::Slots,
+};
+
+fn test_intent() -> Intent {
+    Intent {
+        slots: Slots {
+            decision_variables: 1,
+            state: Default::default(),
+        },
+        state_read: Default::default(),
+        constraints: Default::default(),
+        directive: Directive::Satisfy,
+    }
+}
+
+#[test]
+fn serialize_intent() {
+    let serialization = essential_hash::serialize(&test_intent());
+    let hex = hex::encode(&serialization);
+    let expected_hex = "0100000000";
+    assert_eq!(hex, expected_hex);
+}
+
+#[test]
+fn hash_intent() {
+    let hash = essential_hash::hash(&test_intent());
+    let expected_hash_hex = "957b88b12730e646e0f33d3618b77dfa579e8231e3c59c7104be7165611c8027";
+    let hex = hex::encode(&hash);
+    assert_eq!(hex, expected_hash_hex);
+}


### PR DESCRIPTION
This extracts the essential_server's `utils` hashing related functions and tests into a dedicated, minimal `essential-hash` crate.

This is a minimal step in the process of refactoring essential-server's state transition verification logic into `essential-base`, #81.