### PR TITLE
feat: Introduce a minimal `essential-sign` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "essential-sign"
+version = "0.1.0"
+dependencies = [
+ "essential-hash",
+ "essential-types",
+ "hex",
+ "rand",
+ "secp256k1",
+ "serde",
+]
+
+[[package]]
 name = "essential-state-asm"
 version = "0.1.0"
 dependencies = [
@@ -697,6 +709,25 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secp256k1"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+dependencies = [
+ "rand",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ essential-asm-gen = { path = "crates/asm-gen" }
 essential-asm-spec = { path = "crates/asm-spec" }
 essential-constraint-asm = { path = "crates/constraint-asm" }
 essential-constraint-vm = { path = "crates/constraint-vm" }
+essential-hash = { path = "crates/hash" }
+essential-sign = { path = "crates/sign" }
 essential-state-asm = { path = "crates/state-asm" }
 essential-state-read-vm = { path = "crates/state-read-vm" }
 essential-types = { path = "crates/types" }
@@ -22,6 +24,7 @@ quote = "1"
 rand = { version = "0.8", features = ["small_rng"] } # For VM tests.
 rayon = "1" # For `constraint-vm` parallelisation.
 schemars = "0.8.16"
+secp256k1 = { version = "0.28.2", features = ["recovery"] }
 serde = { version = "1.0.195", features = ["derive"] }
 serde_yaml = "0.9"
 sha2 = "0.10.8"

--- a/crates/sign/Cargo.toml
+++ b/crates/sign/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "essential-sign"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+essential-hash = { workspace = true }
+essential-types = { workspace = true }
+secp256k1 = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+hex = { workspace = true }
+rand = { workspace = true }
+secp256k1 = { workspace = true, features = ["rand-std"] }

--- a/crates/sign/src/lib.rs
+++ b/crates/sign/src/lib.rs
@@ -1,0 +1,64 @@
+//! A minimal crate providing Essential's generic signing, verification
+//! and public key recovery functions implemented using [`secp256k1`] and the
+//! [`essential_hash`] crate.
+//!
+//! Includes [`sign`], [`verify`], [`recover`] and [`recover_from_message`].
+
+#![deny(missing_docs)]
+#![deny(unsafe_code)]
+
+use essential_hash::hash;
+use essential_types::{Signature, Signed};
+use secp256k1::{
+    ecdsa::{RecoverableSignature, RecoveryId},
+    Message, PublicKey, Secp256k1, SecretKey,
+};
+use serde::Serialize;
+
+/// Sign over data with secret key using secp256k1 curve.
+pub fn sign<T: Serialize>(data: T, sk: SecretKey) -> Signed<T> {
+    let secp = Secp256k1::new();
+    let hashed_data = hash(&data);
+    let message = Message::from_digest(hashed_data);
+    let (rec_id, sig) = secp
+        .sign_ecdsa_recoverable(&message, &sk)
+        .serialize_compact();
+    let signature: Signature = Signature(sig, rec_id.to_i32().try_into().unwrap());
+    Signed { data, signature }
+}
+
+/// Verify signature against data.
+pub fn verify<T: Serialize>(signed: &Signed<T>) -> bool {
+    let secp = Secp256k1::new();
+    let hashed_data = hash(&signed.data);
+    let message = Message::from_digest(hashed_data);
+    if let Ok(pk) = recover_from_message(message, &signed.signature) {
+        secp.verify_ecdsa(
+            &message,
+            &secp256k1::ecdsa::Signature::from_compact(&signed.signature.0).unwrap(),
+            &pk,
+        )
+        .is_ok()
+    } else {
+        false
+    }
+}
+
+/// Recover public key from `Signed.data` and `Signed.signature`
+pub fn recover<T: Serialize>(signed: Signed<T>) -> Result<PublicKey, secp256k1::Error> {
+    let hashed_data = hash(&signed.data);
+    let message = Message::from_digest(hashed_data);
+    recover_from_message(message, &signed.signature)
+}
+
+/// Recover public key from signed `secp256k1::Message` and `Signature`
+pub fn recover_from_message(
+    message: Message,
+    signature: &Signature,
+) -> Result<PublicKey, secp256k1::Error> {
+    let recovery_id = RecoveryId::from_i32(i32::from(signature.1))?;
+    let recoverable_signature = RecoverableSignature::from_compact(&signature.0, recovery_id)?;
+    let secp = Secp256k1::new();
+    let public_key = secp.recover_ecdsa(&message, &recoverable_signature)?;
+    Ok(public_key)
+}

--- a/crates/sign/tests/sign.rs
+++ b/crates/sign/tests/sign.rs
@@ -1,0 +1,68 @@
+use essential_sign::sign;
+use essential_types::{
+    intent::{Directive, Intent},
+    slots::Slots,
+    Signature,
+};
+use rand::SeedableRng;
+use secp256k1::{PublicKey, Secp256k1, SecretKey};
+
+fn test_intent() -> Intent {
+    Intent {
+        slots: Slots {
+            decision_variables: 1,
+            state: Default::default(),
+        },
+        state_read: Default::default(),
+        constraints: Default::default(),
+        directive: Directive::Satisfy,
+    }
+}
+
+fn random_keypair(seed: [u8; 32]) -> (SecretKey, PublicKey) {
+    let mut rng = rand::rngs::SmallRng::from_seed(seed);
+    let secp = Secp256k1::new();
+    secp.generate_keypair(&mut rng)
+}
+
+#[test]
+fn sign_intent() {
+    let (sk, _pk) = random_keypair([0xcd; 32]);
+    let signed = sign(test_intent(), sk);
+    let expected_signature_hex = concat!(
+        "641965942f822f382fa5cad859c5906f2acaac4a611e7f8c66d6d1aecde79919",
+        "75aa2c9ae3b0d170c78c39acc49fecafca3c13e92c32c031af113eabdf973239"
+    );
+    let hex = hex::encode(signed.signature.0);
+    assert_eq!(expected_signature_hex, hex);
+}
+
+#[test]
+fn recover() {
+    let (sk, pk) = random_keypair([0xcd; 32]);
+    let data = test_intent();
+    let signed = sign(data, sk);
+    let recovered_pk = essential_sign::recover(signed).unwrap();
+    assert_eq!(pk, recovered_pk);
+}
+
+#[test]
+fn fail_to_recover() {
+    let (sk, _pk) = random_keypair([0xcd; 32]);
+    let data = test_intent();
+    let signed = sign(data, sk);
+    let mut corrupted_signed = signed.clone();
+    corrupted_signed.signature.1 = (corrupted_signed.signature.1 + 1) % 4;
+    assert!(essential_sign::recover(corrupted_signed).is_err());
+}
+
+#[test]
+fn verify_signature() {
+    let (sk, _pk) = random_keypair([0xcd; 32]);
+    let data = test_intent();
+    let signed = sign(data, sk);
+    let mut signed_corrupted = signed.clone();
+    signed_corrupted.signature = Signature([0u8; 64], 0);
+    assert!(essential_sign::verify(&signed));
+    assert!(!essential_sign::verify(&signed_corrupted));
+}


### PR DESCRIPTION
*Based on #82*

This extracts the essential_server's `utils` signing related functions (sign, verify, recover) into a dedicated, minimal `essential-sign` crate.

This is a minimal step in the process of refactoring essential-server's state transition verification logic into `essential-base`, #81.

## To-Do

- [x] Rebase against `main` after #82 lands.