### PR TITLE
fix: Relax trait bounds on associated `Error` types

### DIFF
--- a/crates/constraint-asm/src/lib.rs
+++ b/crates/constraint-asm/src/lib.rs
@@ -34,7 +34,7 @@ mod op {
     /// Operation types that may be parsed from a bytecode representation.
     pub trait TryFromBytes: Sized {
         /// Represents any error that might occur while parsing an op from bytes.
-        type Error: std::error::Error;
+        type Error: core::fmt::Debug + core::fmt::Display;
         /// Parse a single operation from the given iterator yielding bytes.
         ///
         /// Returns `None` in the case that the given iterator is empty.
@@ -61,7 +61,7 @@ pub mod opcode {
         /// The operation associated with the opcode.
         type Op;
         /// Any error that might occur while parsing.
-        type Error;
+        type Error: core::fmt::Debug + core::fmt::Display;
         /// Attempt to parse the operation associated with the opcode from the given bytes.
         ///
         /// Only consumes the bytes necessary to construct any associated data.

--- a/crates/constraint-vm/src/op_access.rs
+++ b/crates/constraint-vm/src/op_access.rs
@@ -12,7 +12,7 @@ pub trait OpAccess {
     /// The operation type being accessed.
     type Op;
     /// Any error that might occur during access.
-    type Error: std::error::Error;
+    type Error: core::fmt::Debug + core::fmt::Display;
     /// Access the operation at the given index.
     ///
     /// Mutable access to self is required in case operations are lazily parsed.

--- a/crates/state-read-vm/src/state_read.rs
+++ b/crates/state-read-vm/src/state_read.rs
@@ -14,7 +14,7 @@ use essential_types::{convert::u8_32_from_word_4, ContentAddress, Key, Word};
 /// Access to state required by the state read VM.
 pub trait StateRead {
     /// An error type describing any cases that might occur during state reading.
-    type Error: std::error::Error;
+    type Error: core::fmt::Debug + core::fmt::Display;
     /// The future type returned from the `word_range` method.
     ///
     /// ## Unpin


### PR DESCRIPTION
Removes the `std::error::Error` bound in favour of bounding by `core::fmt::Debug` and `core::fmt::Display` directly.

This addresses a couple of nits:

1. Better compatibility with `anyhow::Error` that does not impl `std::error::Error`. This is noticably an issue today in `essential-server`.
2. Using only `core` is `#![no_std]` compatible.