### PR TITLE
feat: Enable `#![no-std]` support for `*-asm` crates

### DIFF
--- a/crates/asm-gen/src/lib.rs
+++ b/crates/asm-gen/src/lib.rs
@@ -9,7 +9,7 @@ use proc_macro2::Span;
 use quote::ToTokens;
 use syn::{punctuated::Punctuated, token::Comma};
 
-const WORD_SIZE: usize = std::mem::size_of::<essential_types::Word>();
+const WORD_SIZE: usize = core::mem::size_of::<essential_types::Word>();
 
 /// Document the required bytecode arguments to the operation.
 fn bytecode_arg_docs(num_arg_bytes: u8) -> String {

--- a/crates/constraint-asm/Cargo.toml
+++ b/crates/constraint-asm/Cargo.toml
@@ -7,3 +7,10 @@ version = "0.1.0"
 essential-asm-gen.workspace = true
 essential-types.workspace = true
 serde.workspace = true
+
+[features]
+default = ["std"]
+std = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/constraint-asm/src/lib.rs
+++ b/crates/constraint-asm/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! # Op Table
 #![doc = essential_asm_gen::gen_constraint_ops_docs_table!()]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
@@ -93,8 +94,10 @@ pub mod opcode {
         }
     }
 
+    #[cfg(feature = "std")]
     impl std::error::Error for InvalidOpcodeError {}
 
+    #[cfg(feature = "std")]
     impl std::error::Error for NotEnoughBytesError {}
 
     essential_asm_gen::gen_constraint_opcode_decls!();
@@ -120,6 +123,7 @@ impl fmt::Display for FromBytesError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for FromBytesError {}
 
 impl From<InvalidOpcodeError> for FromBytesError {

--- a/crates/state-asm/Cargo.toml
+++ b/crates/state-asm/Cargo.toml
@@ -7,3 +7,10 @@ version = "0.1.0"
 essential-asm-gen.workspace = true
 essential-constraint-asm.workspace = true
 serde.workspace = true
+
+[features]
+default = ["std"]
+std = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/state-asm/src/lib.rs
+++ b/crates/state-asm/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! # Op Table
 #![doc = essential_asm_gen::gen_ops_docs_table!()]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
@@ -42,7 +43,7 @@ pub fn from_bytes(
     bytes: impl IntoIterator<Item = u8>,
 ) -> impl Iterator<Item = Result<Op, FromBytesError>> {
     let mut iter = bytes.into_iter();
-    std::iter::from_fn(move || Op::try_from_bytes(&mut iter))
+    core::iter::from_fn(move || Op::try_from_bytes(&mut iter))
 }
 
 /// Convert the given iterator yielding operations into and iterator yielding


### PR DESCRIPTION
Small tweaks to the `*-asm` crates to make them `#![no_std]` compatible. This just adds some flexibility, and makes sure that CI will notify us if we lose the option by adding something from `std`.

I also intended on tweaking `types`, but there are a few ways to go about dealing with `Vec` (i.e. introduing alloc, switching to ArrayVec, etc) so figured I'd leave it for when we actually need it.

## To-Do

- [x] Land #95.