### PR TITLE
ci: build workspace for `wasm32-unknown-unknown` target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+        target: wasm32-unknown-unknown
     - uses: Swatinem/rust-cache@v2
     - run: cargo ${{ matrix.command }}
 


### PR DESCRIPTION
Tiny PR to ensure we maintain `wasm32-unknown-unknown` compatibility throughout `essential-base`.