### PR TITLE
feat: Add fmt LowerHex, UpperHex and Display impls for ContentAddress

### DIFF
--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 
-use essential_types::Hash;
+use essential_types::{ContentAddress, Hash};
 use serde::Serialize;
 use sha2::Digest;
 
@@ -26,4 +26,11 @@ pub fn hash<T: Serialize>(t: &T) -> Hash {
     let mut hasher = <sha2::Sha256 as sha2::Digest>::new();
     hasher.update(&data);
     hasher.finalize().into()
+}
+
+/// Shorthand for hashing the given value in order to produce its content address.
+///
+/// Commonly useful for solutions, intents and intent sets.
+pub fn content_addr<T: Serialize>(t: &T) -> ContentAddress {
+    ContentAddress(hash(t))
 }

--- a/crates/types/src/fmt.rs
+++ b/crates/types/src/fmt.rs
@@ -1,0 +1,28 @@
+//! `core::fmt` implementations and related items.
+
+use crate::ContentAddress;
+use core::fmt;
+
+impl fmt::LowerHex for ContentAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for ContentAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for byte in self.0 {
+            write!(f, "{byte:02X}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for ContentAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "0x{:x}", self)
+    }
+}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -3,14 +3,13 @@
 //! # Common types for Essential Chain.
 
 use core::time::Duration;
-
+#[cfg(feature = "schema")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use solution::Solution;
 
-#[cfg(feature = "schema")]
-use schemars::JsonSchema;
-
 pub mod convert;
+pub mod fmt;
 pub mod intent;
 pub mod signature_ser;
 pub mod slots;

--- a/crates/types/tests/fmt.rs
+++ b/crates/types/tests/fmt.rs
@@ -1,0 +1,21 @@
+use essential_types::ContentAddress;
+
+#[test]
+fn content_address() {
+    let ca = ContentAddress([
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30, 31,
+    ]);
+    assert_eq!(
+        &format!("{ca:x}"),
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+    );
+    assert_eq!(
+        &format!("{ca:X}"),
+        "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F"
+    );
+    assert_eq!(
+        &format!("{ca}"),
+        "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+    );
+}


### PR DESCRIPTION
After noticing we quite often do something like the following:

```rust
// Add hex crate to toml...

format!("0x{}", hex::encode(essential_hash::hash(&solution)));
```
and
```rust
let ca = ContentAddress(essential_hash::hash(&solution));
```

I thought I'd add the fmt hex and display implementations for `ContentAddress` along with a shorthand constructor.

```rust
format!("{}", essential_hash::content_addr(&solution));
```