### PR TITLE
fix: Remove doubling up of information in `IntentErrors` `Display` impl

### DIFF
--- a/crates/check/src/solution.rs
+++ b/crates/check/src/solution.rs
@@ -95,7 +95,7 @@ pub enum InvalidStateMutations {
 #[derive(Debug, Error)]
 pub enum IntentsError<E> {
     /// One or more solution data failed their associated intent checks.
-    #[error("one or more solution data failed their associated intent checks: {0}")]
+    #[error("{0}")]
     Failed(#[from] IntentErrors<E>),
     /// One or more tasks failed to join.
     #[error("one or more spawned tasks failed to join: {0}")]


### PR DESCRIPTION
The equivalent of the remove sentence is already printed by the variant's inner `IntentErrors` `Display` impl. I noticed this in the last screenshot in #101.