### PR TITLE
fix: Tweak trace behaviour for state-read-vm ops

### DIFF
--- a/crates/state-read-vm/src/future.rs
+++ b/crates/state-read-vm/src/future.rs
@@ -164,7 +164,7 @@ where
 
                 // Handle the op result.
                 #[cfg(feature = "tracing")]
-                trace_op_res(vm.pc, &mut self.op_access, &*vm, res.as_ref());
+                trace_op_res(&mut self.op_access, &*vm, res.as_ref());
 
                 match res {
                     Ok(new_pc) => vm.pc = new_pc,
@@ -228,7 +228,7 @@ where
             };
 
             #[cfg(feature = "tracing")]
-            trace_op_res(vm.pc, &mut self.op_access, &*vm, res.as_ref());
+            trace_op_res(&mut self.op_access, &*vm, res.as_ref());
 
             // Handle any errors.
             let opt_new_pc = match res {
@@ -351,7 +351,7 @@ fn out_of_gas(exec: &GasExec, op_gas: Gas) -> OutOfGasError {
 ///
 /// In the error case, emits a debug log with the error.
 #[cfg(feature = "tracing")]
-fn trace_op_res<OA, T, E>(pc: usize, oa: &mut OA, vm: &Vm, op_res: Result<T, E>)
+fn trace_op_res<OA, T, E>(oa: &mut OA, vm: &Vm, op_res: Result<T, E>)
 where
     OA: OpAccess,
     OA::Op: core::fmt::Debug,
@@ -361,7 +361,7 @@ where
         .op_access(vm.pc)
         .expect("must exist as retrieved previously")
         .expect("must exist as retrieved previously");
-    let pc_op = format!("0x{pc:02X}: {op:?}");
+    let pc_op = format!("0x{:02X}: {op:?}", vm.pc);
     match op_res {
         Ok(_) => {
             tracing::trace!("{pc_op}\n  ├── {:?}\n  └── {:?}", &vm.stack, &vm.memory)


### PR DESCRIPTION
Small PR to address [this comment](https://github.com/essential-contributions/essential-base/pull/101/files#r1602516795). The core takeaway is that the sync op results are handled in a different location to the async op results - I've added a function for the shared logic between the two!

I realised we might also want to emit the memory for debugging the state read VM, then ran into bigger vertical alignment issues affecting readability when testing. Then realised we can still do multi-line logs within a single trace log!

cc @supiket @freesig what are your thoughts on something like this:

![Screenshot from 2024-05-16 16-28-11](https://github.com/essential-contributions/essential-base/assets/4587373/9413e565-d2ad-41e9-8131-fde18327f6b4)

Could even consider logging the `vm.repeat` and `vm.temp_memory`...? Maybe only in the case they're non-empty?