### PR TITLE
feat: Add MutKeys and EqSet

### DIFF
--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -169,7 +169,7 @@ StateRead:
                 `[elem_0_word_0, ...elem_0_word_I, elem_0_len, ...elem_N_word_0, ...elem_N_word_J, elem_N_len, set_len]`.
 
                 Note this differs from `EqRange` in that there is a size given at the end of both sets.
-              stack_in: [lhs, rhs, set_length]
+              stack_in: [lhs, lhs_set_length, rhs, rhs_set_length]
               stack_out: [set(lhs) == set(rhs)]
 
         Alu:

--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -158,6 +158,20 @@ StateRead:
               stack_in: [a]
               stack_out: ["!a"]
 
+            EqSet:
+              opcode: 0x19
+              description: |
+                Pop two sets off the stack and check if they are equal.
+                This is set equality so order does not matter.
+                Sets must be the same length.
+
+                Note the encoding of each set is:
+                `[elem_0_word_0, ...elem_0_word_I, elem_0_len, ...elem_N_word_0, ...elem_N_word_J, elem_N_len, set_len]`.
+
+                Note this differs from `EqRange` in that there is a size given at the end of both sets.
+              stack_in: [lhs, rhs, set_length]
+              stack_out: [set(lhs) == set(rhs)]
+
         Alu:
           description: Operations for computing arithmetic and logic.
           group:
@@ -301,25 +315,15 @@ StateRead:
                 elem: length
                 len: range
 
-            MutKeysLen:
+            MutKeys:
               opcode: 0x38
               description: |
-                Get the number of mutable keys being proposed for mutation.
-
-                This operation returns a single word representing the length.
-              stack_out: [word]
-
-            MutKeysContains:
-              opcode: 0x39
-              description: |
-                Check if the mutable keys being proposed contain the given key.
-
-                This operation returns a true if the key is found, false otherwise.
-              stack_in: [key, key_len]
-              stack_out: [bool]
+                Push the keys of the proposed state mutations onto the stack.
+                Note the order is non-deterministic because this is a set.
+              stack_out: [key_0, key_0_len, ...key_N, key_N_len, total_length]
 
             ThisAddress:
-              opcode: 0x3A
+              opcode: 0x39
               description: |
                 Get the content hash of this predicate.
 
@@ -327,7 +331,7 @@ StateRead:
               stack_out: [key]
 
             ThisContractAddress:
-              opcode: 0x3B
+              opcode: 0x3A
               description: |
                 Get the content hash of the contract this predicate belongs to.
 
@@ -335,7 +339,7 @@ StateRead:
               stack_out: [key]
 
             ThisPathway:
-              opcode: 0x3C
+              opcode: 0x3B
               description: |
                 Get the pathway of this predicate.
 
@@ -343,12 +347,12 @@ StateRead:
               stack_out: [in]
 
             RepeatCounter:
-              opcode: 0x3D
+              opcode: 0x3C
               description: Access the top repeat counters current value.
               stack_out: [counter_value]
 
             Transient:
-              opcode: 0x3E
+              opcode: 0x3D
               description: Get the solution data indexed by pathway and key.
               stack_in: [key_0, ...key_N, key_len, pathway]
               stack_out:
@@ -356,13 +360,13 @@ StateRead:
                 len: value_len
 
             TransientLen:
-              opcode: 0x3F
+              opcode: 0x3E
               description: Get the length of solution data indexed by pathway and key.
               stack_in: [key_0, ...key_N, key_len, pathway]
               stack_out: [len]
 
             PredicateAt:
-              opcode: 0x40
+              opcode: 0x3F
               description: Get the predicate at solution data pathway.
               stack_in: [pathway]
               stack_out:
@@ -378,12 +382,12 @@ StateRead:
                 ]
 
             ThisTransientLen:
-              opcode: 0x41
+              opcode: 0x40
               description: Get the length of the transient data at this predicate.
               stack_out: [len]
 
             ThisTransientContains:
-              opcode: 0x42
+              opcode: 0x41
               description: Check if the transient data at this predicate contains the given key.
               stack_in: [key_0, ...key_N, key_len]
               stack_out: [bool]

--- a/crates/constraint-vm/src/access.rs
+++ b/crates/constraint-vm/src/access.rs
@@ -192,23 +192,35 @@ pub(crate) fn decision_var_len(solution: SolutionAccess, stack: &mut Stack) -> O
     })
 }
 
-/// `Access::MutKeysLen` implementation.
-pub(crate) fn mut_keys_len(solution: SolutionAccess, stack: &mut Stack) -> OpResult<()> {
-    stack.push(
-        solution
-            .mutable_keys
-            .len()
-            .try_into()
-            .map_err(|_| AccessError::SolutionDataOutOfBounds)?,
+/// `Access::MutKeys` implementation.
+pub(crate) fn push_mut_keys(solution: SolutionAccess, stack: &mut Stack) -> OpResult<()> {
+    let length = solution
+        .mutable_keys
+        .iter()
+        .map(|i| i.len())
+        .sum::<usize>()
+        .checked_add(solution.mutable_keys.len());
+    let total_length = length.and_then(|i| Word::try_from(i).ok()).ok_or(
+        AccessError::StateMutationsLengthTooLarge(solution.mutable_keys.len()),
     )?;
-    Ok(())
-}
-
-pub(crate) fn mut_keys_contains(solution: SolutionAccess, stack: &mut Stack) -> OpResult<()> {
-    let found = stack.pop_len_words::<_, bool, crate::error::OpError>(|words| {
-        Ok(solution.mutable_keys.contains(words))
-    })?;
-    stack.push(Word::from(found))?;
+    let iter = solution
+        .mutable_keys
+        .iter()
+        .filter(|key| {
+            // This should never happen because keys have
+            // a capped size but we don't want to return
+            // an error because it would require collecting
+            // into a vec. But we also don't want to panic.
+            key.len() <= (Word::MAX as usize)
+        })
+        .flat_map(|key| {
+            key.iter()
+                .copied()
+                // Safe cast due to above filter
+                .chain(core::iter::once(key.len() as Word))
+        });
+    stack.extend(iter)?;
+    stack.push(total_length)?;
     Ok(())
 }
 

--- a/crates/constraint-vm/src/error.rs
+++ b/crates/constraint-vm/src/error.rs
@@ -81,6 +81,9 @@ pub enum OpError {
     /// Pc counter overflowed.
     #[error("PC counter overflowed")]
     PcOverflow,
+    /// An error occurred while decoding some data.
+    #[error("decoding error: {0}")]
+    Decode(#[from] DecodeError),
 }
 
 /// Access operation error.
@@ -110,6 +113,9 @@ pub enum AccessError {
     /// A state slot delta value was invalid. Must be `0` (pre) or `1` (post).
     #[error("invalid state slot delta: expected `0` or `1`, found {0}")]
     InvalidStateSlotDelta(Word),
+    /// The total length of the set of state mutations was too large.
+    #[error("the total length of the set of state mutations was too large: {0}")]
+    StateMutationsLengthTooLarge(usize),
 }
 
 /// ALU operation error.
@@ -216,6 +222,14 @@ pub enum TemporaryError {
     /// The memory size exceeded the size limit.
     #[error("the {}-word stack size limit was exceeded", crate::Memory::SIZE_LIMIT)]
     Overflow,
+}
+
+/// Decode error.
+#[derive(Debug, Error)]
+pub enum DecodeError {
+    /// Decoding a set failed.
+    #[error("failed to decode set: {0:?}")]
+    Set(Vec<Word>),
 }
 
 impl fmt::Display for ConstraintErrors {

--- a/crates/constraint-vm/src/lib.rs
+++ b/crates/constraint-vm/src/lib.rs
@@ -248,8 +248,7 @@ pub fn step_op_access(
         asm::Access::DecisionVarAt => access::decision_var_at(access.solution, stack),
         asm::Access::DecisionVarRange => access::decision_var_range(access.solution, stack),
         asm::Access::DecisionVarLen => access::decision_var_len(access.solution, stack),
-        asm::Access::MutKeysLen => access::mut_keys_len(access.solution, stack),
-        asm::Access::MutKeysContains => access::mut_keys_contains(access.solution, stack),
+        asm::Access::MutKeys => access::push_mut_keys(access.solution, stack),
         asm::Access::State => access::state(access.state_slots, stack),
         asm::Access::StateRange => access::state_range(access.state_slots, stack),
         asm::Access::StateLen => access::state_len(access.state_slots, stack),
@@ -304,6 +303,7 @@ pub fn step_op_pred(op: asm::Pred, stack: &mut Stack) -> OpResult<()> {
         asm::Pred::And => stack.pop2_push1(|a, b| Ok((a != 0 && b != 0).into())),
         asm::Pred::Or => stack.pop2_push1(|a, b| Ok((a != 0 || b != 0).into())),
         asm::Pred::Not => stack.pop1_push1(|a| Ok((a == 0).into())),
+        asm::Pred::EqSet => pred::eq_set(stack),
     }
 }
 

--- a/crates/constraint-vm/src/pred.rs
+++ b/crates/constraint-vm/src/pred.rs
@@ -1,5 +1,9 @@
+use std::collections::HashSet;
+
+use essential_types::Word;
+
 use crate::{
-    error::{OpError, StackError},
+    error::{DecodeError, OpError, StackError},
     OpResult, Stack,
 };
 
@@ -31,4 +35,82 @@ pub(crate) fn eq_range(stack: &mut Stack) -> OpResult<()> {
     stack.push(eq.into())?;
 
     Ok(())
+}
+
+/// `Pred::EqSet` implementation.
+pub(crate) fn eq_set(stack: &mut Stack) -> OpResult<()> {
+    // Pop the length off the stack.
+    let rhs_len = stack.pop()?;
+
+    // If the length is 0, the sets are both empty set and are equal.
+    if rhs_len == 0 {
+        let lhs_len = stack.pop()?;
+        if lhs_len == 0 {
+            stack.push(1.into())?;
+        } else {
+            stack.push(lhs_len)?;
+            stack.pop_len_discard()?;
+            stack.push(0.into())?;
+        }
+        return Ok(());
+    }
+
+    let rhs_len: usize = rhs_len
+        .try_into()
+        .map_err(|_| StackError::IndexOutOfBounds)?;
+
+    // Check the lens are equal.
+    let lhs_len_ix = rhs_len
+        .checked_add(1)
+        .and_then(|i| stack.len().checked_sub(i))
+        .ok_or(StackError::IndexOutOfBounds)?;
+    let lhs_len = stack.get(lhs_len_ix).ok_or(StackError::IndexOutOfBounds)?;
+    let lhs_len: usize = (*lhs_len)
+        .try_into()
+        .map_err(|_| StackError::IndexOutOfBounds)?;
+
+    let full_len: Word = rhs_len
+        .checked_add(1)
+        .and_then(|i| lhs_len.checked_add(i))
+        .ok_or(StackError::IndexOutOfBounds)?
+        .try_into()
+        .map_err(|_| StackError::IndexOutOfBounds)?;
+    let not_eq_sizes = lhs_len != rhs_len;
+
+    stack.push(full_len)?;
+
+    let eq = stack.pop_len_words::<_, _, OpError>(|words| {
+        if not_eq_sizes {
+            return Ok(false);
+        }
+        let (lhs, rhs) = words.split_at(rhs_len);
+        // Discard lhs len from start of rhs.
+        let rhs = rhs.get(1..).ok_or(StackError::IndexOutOfBounds)?;
+        let eq = decode_set(lhs)? == decode_set(rhs)?;
+
+        Ok(eq)
+    })?;
+
+    // Push the result back onto the stack.
+    stack.push(eq.into())?;
+
+    Ok(())
+}
+
+/// Decode a set from a slice of words.
+/// The slice is in order from bottom to top of stack.
+fn decode_set(mut set: &[Word]) -> OpResult<HashSet<&[Word]>> {
+    let s = set;
+    let mut out = HashSet::new();
+    while let Some((&len, rest)) = set.split_last() {
+        let len: usize = len.try_into().map_err(|_| StackError::Overflow)?;
+        let ix = rest
+            .len()
+            .checked_sub(len)
+            .ok_or_else(|| DecodeError::Set(s.to_vec()))?;
+        let (rest, elem) = rest.split_at(ix);
+        out.insert(elem);
+        set = rest;
+    }
+    Ok(out)
 }

--- a/crates/constraint-vm/src/pred.rs
+++ b/crates/constraint-vm/src/pred.rs
@@ -39,78 +39,32 @@ pub(crate) fn eq_range(stack: &mut Stack) -> OpResult<()> {
 
 /// `Pred::EqSet` implementation.
 pub(crate) fn eq_set(stack: &mut Stack) -> OpResult<()> {
-    // Pop the length off the stack.
-    let rhs_len = stack.pop()?;
-
-    // If the length is 0, the sets are both empty set and are equal.
-    if rhs_len == 0 {
-        let lhs_len = stack.pop()?;
-        if lhs_len == 0 {
-            stack.push(1.into())?;
-        } else {
-            stack.push(lhs_len)?;
-            stack.pop_len_discard()?;
-            stack.push(0.into())?;
-        }
-        return Ok(());
-    }
-
-    let rhs_len: usize = rhs_len
-        .try_into()
-        .map_err(|_| StackError::IndexOutOfBounds)?;
-
-    // Check the lens are equal.
-    let lhs_len_ix = rhs_len
-        .checked_add(1)
-        .and_then(|i| stack.len().checked_sub(i))
-        .ok_or(StackError::IndexOutOfBounds)?;
-    let lhs_len = stack.get(lhs_len_ix).ok_or(StackError::IndexOutOfBounds)?;
-    let lhs_len: usize = (*lhs_len)
-        .try_into()
-        .map_err(|_| StackError::IndexOutOfBounds)?;
-
-    let full_len: Word = rhs_len
-        .checked_add(1)
-        .and_then(|i| lhs_len.checked_add(i))
-        .ok_or(StackError::IndexOutOfBounds)?
-        .try_into()
-        .map_err(|_| StackError::IndexOutOfBounds)?;
-    let not_eq_sizes = lhs_len != rhs_len;
-
-    stack.push(full_len)?;
-
-    let eq = stack.pop_len_words::<_, _, OpError>(|words| {
-        if not_eq_sizes {
-            return Ok(false);
-        }
-        let (lhs, rhs) = words.split_at(rhs_len);
-        // Discard lhs len from start of rhs.
-        let rhs = rhs.get(1..).ok_or(StackError::IndexOutOfBounds)?;
-        let eq = decode_set(lhs)? == decode_set(rhs)?;
-
-        Ok(eq)
+    let eq = stack.pop_len_words2::<_, _, OpError>(|lhs, rhs| {
+        let lhs = unflatten_keys(lhs).collect::<Result<HashSet<&[Word]>, _>>()?;
+        let rhs = unflatten_keys(rhs).collect::<Result<HashSet<&[Word]>, _>>()?;
+        Ok(lhs == rhs)
     })?;
-
-    // Push the result back onto the stack.
     stack.push(eq.into())?;
-
     Ok(())
 }
 
-/// Decode a set from a slice of words.
-/// The slice is in order from bottom to top of stack.
-fn decode_set(mut set: &[Word]) -> OpResult<HashSet<&[Word]>> {
-    let s = set;
-    let mut out = HashSet::new();
-    while let Some((&len, rest)) = set.split_last() {
-        let len: usize = len.try_into().map_err(|_| StackError::Overflow)?;
-        let ix = rest
-            .len()
-            .checked_sub(len)
-            .ok_or_else(|| DecodeError::Set(s.to_vec()))?;
-        let (rest, elem) = rest.split_at(ix);
-        out.insert(elem);
-        set = rest;
-    }
-    Ok(out)
+/// Unflatten the keys, starting from the top of slice.
+fn unflatten_keys(words: &[Word]) -> impl '_ + Iterator<Item = OpResult<&[Word]>> {
+    let mut ws = words;
+    std::iter::from_fn(move || {
+        let (len, rest) = ws.split_last()?;
+        let ix = match usize::try_from(*len)
+            .map_err(|_| StackError::Overflow.into())
+            .and_then(|len| {
+                rest.len()
+                    .checked_sub(len)
+                    .ok_or_else(|| DecodeError::Set(words.to_vec()).into())
+            }) {
+            Ok(ix) => ix,
+            Err(e) => return Some(Err(e)),
+        };
+        let (rest, key) = rest.split_at(ix);
+        ws = rest;
+        Some(Ok(key))
+    })
 }

--- a/crates/constraint-vm/src/pred/tests.rs
+++ b/crates/constraint-vm/src/pred/tests.rs
@@ -32,12 +32,15 @@ fn test_eq_empty_range() {
 fn test_decode_set() {
     let set = [0, 1, 2, 3, 3, 4, 5, 3, 6, 1];
     let expect: [&[Word]; 3] = [&[0, 1, 2], &[3, 4, 5], &[6]];
-    assert_eq!(decode_set(&set).unwrap(), expect.into_iter().collect());
+    let lhs = unflatten_keys(&set)
+        .collect::<Result<HashSet<_>, _>>()
+        .unwrap();
+    let rhs = expect.into_iter().collect();
+    assert_eq!(lhs, rhs);
 
     let set = [0, 1, 2, 4, 3, 4, 5, 3, 6, 1];
-    assert!(
-        matches!(decode_set(&set).unwrap_err(), OpError::Decode(DecodeError::Set(s)) if s == set)
-    );
+    let res = unflatten_keys(&set).collect::<Result<Vec<_>, _>>();
+    assert!(matches!(res.unwrap_err(), OpError::Decode(DecodeError::Set(s)) if s == set));
 }
 
 #[test]

--- a/crates/constraint-vm/src/pred/tests.rs
+++ b/crates/constraint-vm/src/pred/tests.rs
@@ -27,3 +27,96 @@ fn test_eq_empty_range() {
     eq_range(&mut stack).unwrap();
     assert_eq!(stack.pop().unwrap(), 1);
 }
+
+#[test]
+fn test_decode_set() {
+    let set = [0, 1, 2, 3, 3, 4, 5, 3, 6, 1];
+    let expect: [&[Word]; 3] = [&[0, 1, 2], &[3, 4, 5], &[6]];
+    assert_eq!(decode_set(&set).unwrap(), expect.into_iter().collect());
+
+    let set = [0, 1, 2, 4, 3, 4, 5, 3, 6, 1];
+    assert!(
+        matches!(decode_set(&set).unwrap_err(), OpError::Decode(DecodeError::Set(s)) if s == set)
+    );
+}
+
+#[test]
+fn test_eq_set() {
+    let set_a = [0, 1, 2, 3, 3, 4, 5, 3, 6, 1, 10];
+    let set_b = set_a;
+    let mut stack = Stack::default();
+
+    // Equal sets.
+    stack.extend(set_a).unwrap();
+    stack.extend(set_b).unwrap();
+    eq_set(&mut stack).unwrap();
+    assert_eq!(stack.pop().unwrap(), 1);
+    assert!(stack.is_empty());
+
+    // Unequal sets of the same length.
+    let set_c = [1, 1, 2, 3, 3, 4, 5, 3, 6, 1, 10];
+    stack.extend(set_a).unwrap();
+    stack.extend(set_c).unwrap();
+    eq_set(&mut stack).unwrap();
+    assert_eq!(stack.pop().unwrap(), 0);
+    assert!(stack.is_empty());
+
+    // Order doesn't matter.
+    stack.extend(set_c).unwrap();
+    stack.extend(set_a).unwrap();
+    eq_set(&mut stack).unwrap();
+    assert_eq!(stack.pop().unwrap(), 0);
+    assert!(stack.is_empty());
+
+    let set_d = [1, 1, 2, 3, 4];
+
+    // Unequal sets of different lengths.
+    stack.extend(set_c).unwrap();
+    stack.extend(set_d).unwrap();
+    eq_set(&mut stack).unwrap();
+    assert_eq!(stack.pop().unwrap(), 0);
+    assert!(stack.is_empty());
+
+    // Empty set.
+    let empty_set = [0];
+    stack.extend(empty_set).unwrap();
+    stack.extend(empty_set).unwrap();
+    eq_set(&mut stack).unwrap();
+    assert_eq!(stack.pop().unwrap(), 1);
+    assert!(stack.is_empty());
+
+    // Empty set and non-empty set.
+    stack.extend(empty_set).unwrap();
+    stack.extend(set_a).unwrap();
+    eq_set(&mut stack).unwrap();
+    assert_eq!(stack.pop().unwrap(), 0);
+    assert!(stack.is_empty());
+
+    // Order doesn't matter.
+    stack.extend(set_a).unwrap();
+    stack.extend(empty_set).unwrap();
+    eq_set(&mut stack).unwrap();
+    assert_eq!(stack.pop().unwrap(), 0);
+    assert!(stack.is_empty());
+
+    // Decode error lhs.
+    let set_err = [0, 1, 2, 3, 3, 4, 5, 9, 6, 1, 10];
+    stack.extend(set_err).unwrap();
+    stack.extend(set_a).unwrap();
+    let e = eq_set(&mut stack).unwrap_err();
+    assert!(matches!(e, OpError::Decode(DecodeError::Set(s)) if s == set_err[..10]));
+
+    // Decode error rhs.
+    let set_err = [0, 1, 2, 3, 3, 4, 5, 9, 6, 1, 10];
+    stack.extend(set_a).unwrap();
+    stack.extend(set_err).unwrap();
+    let e = eq_set(&mut stack).unwrap_err();
+    assert!(matches!(e, OpError::Decode(DecodeError::Set(s)) if s == set_err[..10]));
+
+    // Decode error both.
+    let set_err = [0, 1, 2, 3, 3, 4, 5, 9, 6, 1, 10];
+    stack.extend(set_err).unwrap();
+    stack.extend(set_err).unwrap();
+    let e = eq_set(&mut stack).unwrap_err();
+    assert!(matches!(e, OpError::Decode(DecodeError::Set(s)) if s == set_err[..10]));
+}

--- a/crates/constraint-vm/src/stack.rs
+++ b/crates/constraint-vm/src/stack.rs
@@ -252,6 +252,12 @@ impl Stack {
         self.0.truncate(rest.len());
         Ok(out)
     }
+
+    /// Reserve additional capacity for the stack.
+    /// Noop if capacity already exists.
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional);
+    }
 }
 
 /// Split a length from the top of the stack slice, then split off a slice of

--- a/crates/constraint-vm/src/stack.rs
+++ b/crates/constraint-vm/src/stack.rs
@@ -241,6 +241,17 @@ impl Stack {
         self.0.truncate(ix);
         Ok(out)
     }
+
+    /// Pop the length from the top of the stack, then discard that many words.
+    pub fn pop_len_discard(&mut self) -> StackResult<()> {
+        let len = self.pop_len()?;
+        let ix = self
+            .len()
+            .checked_sub(len)
+            .ok_or(StackError::IndexOutOfBounds)?;
+        self.0.truncate(ix);
+        Ok(())
+    }
 }
 
 impl From<Stack> for Vec<Word> {


### PR DESCRIPTION
Also removes `MutKeysContains` and `MutKeysLen`.

# MutKeys
Pushes the mutable keys onto the stack.
The order is unknown as this is a set.
The encoding is:
```
[key_0, key_0_len, ...key_N, key_N_len, total_length]
```
Note that `key_0` might not be the first key in the mutations.

# EqSet
Compares two sets for equality.
Sets are encoded as:
```
[key_0, key_0_len, ...key_N, key_N_len, total_length]
```
So the input would look like:
```
[
  set_A_key_0, set_A_key_0_len, ...set_A_key_N, set_A_key_N_len, set_A_total_length,
  set_B_key_0, set_B_key_0_len, ...set_B_key_N, set_B_key_N_len, set_B_total_length
]
```
Note there is a length for both sets (which differs to `EqRange`). This is required to prevent the ordering of equality mattering. If we only use a single length then something like:
```
[mut_key_0, mut_key0, 2, mut_key_1, 1, 0]
```
Would return true.
This leads to a security problem where if the set that is being compared to the mut keys is empty then the check passes unless mut_keys is the `rhs`.
This dependency on ordering is too dangerous so having both lengths is required.
