### PR TITLE
refactor: Small tweaks to #155, refactor out `Stack::pop_len_words2`

### DIFF
--- a/crates/constraint-vm/src/pred.rs
+++ b/crates/constraint-vm/src/pred.rs
@@ -39,78 +39,32 @@ pub(crate) fn eq_range(stack: &mut Stack) -> OpResult<()> {
 
 /// `Pred::EqSet` implementation.
 pub(crate) fn eq_set(stack: &mut Stack) -> OpResult<()> {
-    // Pop the length off the stack.
-    let rhs_len = stack.pop()?;
-
-    // If the length is 0, the sets are both empty set and are equal.
-    if rhs_len == 0 {
-        let lhs_len = stack.pop()?;
-        if lhs_len == 0 {
-            stack.push(1.into())?;
-        } else {
-            stack.push(lhs_len)?;
-            stack.pop_len_discard()?;
-            stack.push(0.into())?;
-        }
-        return Ok(());
-    }
-
-    let rhs_len: usize = rhs_len
-        .try_into()
-        .map_err(|_| StackError::IndexOutOfBounds)?;
-
-    // Check the lens are equal.
-    let lhs_len_ix = rhs_len
-        .checked_add(1)
-        .and_then(|i| stack.len().checked_sub(i))
-        .ok_or(StackError::IndexOutOfBounds)?;
-    let lhs_len = stack.get(lhs_len_ix).ok_or(StackError::IndexOutOfBounds)?;
-    let lhs_len: usize = (*lhs_len)
-        .try_into()
-        .map_err(|_| StackError::IndexOutOfBounds)?;
-
-    let full_len: Word = rhs_len
-        .checked_add(1)
-        .and_then(|i| lhs_len.checked_add(i))
-        .ok_or(StackError::IndexOutOfBounds)?
-        .try_into()
-        .map_err(|_| StackError::IndexOutOfBounds)?;
-    let not_eq_sizes = lhs_len != rhs_len;
-
-    stack.push(full_len)?;
-
-    let eq = stack.pop_len_words::<_, _, OpError>(|words| {
-        if not_eq_sizes {
-            return Ok(false);
-        }
-        let (lhs, rhs) = words.split_at(rhs_len);
-        // Discard lhs len from start of rhs.
-        let rhs = rhs.get(1..).ok_or(StackError::IndexOutOfBounds)?;
-        let eq = decode_set(lhs)? == decode_set(rhs)?;
-
-        Ok(eq)
+    let eq = stack.pop_len_words2::<_, _, OpError>(|lhs, rhs| {
+        let lhs = unflatten_keys(lhs).collect::<Result<HashSet<&[Word]>, _>>()?;
+        let rhs = unflatten_keys(rhs).collect::<Result<HashSet<&[Word]>, _>>()?;
+        Ok(lhs == rhs)
     })?;
-
-    // Push the result back onto the stack.
     stack.push(eq.into())?;
-
     Ok(())
 }
 
-/// Decode a set from a slice of words.
-/// The slice is in order from bottom to top of stack.
-fn decode_set(mut set: &[Word]) -> OpResult<HashSet<&[Word]>> {
-    let s = set;
-    let mut out = HashSet::new();
-    while let Some((&len, rest)) = set.split_last() {
-        let len: usize = len.try_into().map_err(|_| StackError::Overflow)?;
-        let ix = rest
-            .len()
-            .checked_sub(len)
-            .ok_or_else(|| DecodeError::Set(s.to_vec()))?;
-        let (rest, elem) = rest.split_at(ix);
-        out.insert(elem);
-        set = rest;
-    }
-    Ok(out)
+/// Unflatten the keys, starting from the top of slice.
+fn unflatten_keys(words: &[Word]) -> impl '_ + Iterator<Item = OpResult<&[Word]>> {
+    let mut ws = words;
+    std::iter::from_fn(move || {
+        let (len, rest) = ws.split_last()?;
+        let ix = match usize::try_from(*len)
+            .map_err(|_| StackError::Overflow.into())
+            .and_then(|len| {
+                rest.len()
+                    .checked_sub(len)
+                    .ok_or_else(|| DecodeError::Set(words.to_vec()).into())
+            }) {
+            Ok(ix) => ix,
+            Err(e) => return Some(Err(e)),
+        };
+        let (rest, key) = rest.split_at(ix);
+        ws = rest;
+        Some(Ok(key))
+    })
 }

--- a/crates/constraint-vm/src/pred/tests.rs
+++ b/crates/constraint-vm/src/pred/tests.rs
@@ -32,12 +32,15 @@ fn test_eq_empty_range() {
 fn test_decode_set() {
     let set = [0, 1, 2, 3, 3, 4, 5, 3, 6, 1];
     let expect: [&[Word]; 3] = [&[0, 1, 2], &[3, 4, 5], &[6]];
-    assert_eq!(decode_set(&set).unwrap(), expect.into_iter().collect());
+    let lhs = unflatten_keys(&set)
+        .collect::<Result<HashSet<_>, _>>()
+        .unwrap();
+    let rhs = expect.into_iter().collect();
+    assert_eq!(lhs, rhs);
 
     let set = [0, 1, 2, 4, 3, 4, 5, 3, 6, 1];
-    assert!(
-        matches!(decode_set(&set).unwrap_err(), OpError::Decode(DecodeError::Set(s)) if s == set)
-    );
+    let res = unflatten_keys(&set).collect::<Result<Vec<_>, _>>();
+    assert!(matches!(res.unwrap_err(), OpError::Decode(DecodeError::Set(s)) if s == set));
 }
 
 #[test]


### PR DESCRIPTION
I noticed a chance to simplify the `eq_set` implementation a little by refactoring out some parts into another potentially useful `Stack` method, so I thought I'd open a little refactor PR against #155. Feel free to take or leave it!