### PR TITLE
feat: remove requirement for halt

### DIFF
--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -463,7 +463,6 @@ StateRead:
               opcode: 0x63
               description: Jump forward the given number of instructions if the value is true.
               panics:
-                - The jump is out of bounds.
                 - The jump is negative.
                 - The jump distance is zero.
               stack_in: [n_instruction, condition]

--- a/crates/state-read-vm/src/future.rs
+++ b/crates/state-read-vm/src/future.rs
@@ -264,8 +264,7 @@ where
             }
         }
 
-        // Programs must complete with a `Halt` operation.
-        Poll::Ready(Err(StateReadError::PcOutOfRange(vm.pc)))
+        Poll::Ready(Ok(self.gas.spent))
     }
 }
 

--- a/crates/state-read-vm/tests/vm.rs
+++ b/crates/state-read-vm/tests/vm.rs
@@ -320,3 +320,25 @@ async fn read_pre_post_state_and_check_constraints() {
 
     // Constraints pass - we're free to apply the updated state!
 }
+
+// Test that halt is not required to end the vm.
+#[tokio::test]
+async fn test_halt() {
+    let mut vm = Vm::default();
+    let ops = &[
+        asm::Stack::Push(6).into(),
+        asm::Stack::Push(7).into(),
+        asm::Alu::Mul.into(),
+    ];
+    let op_gas_cost = &|_: &Op| 1;
+    vm.exec_ops(
+        ops,
+        *test_access(),
+        &State::EMPTY,
+        op_gas_cost,
+        GasLimit::UNLIMITED,
+    )
+    .await
+    .unwrap();
+    assert_eq!(&vm.stack[..], &[42]);
+}


### PR DESCRIPTION
Removes the requirement for a state read program to include halt at the end. This is possible because the program can only move forward or loop a fixed amount of times.