### PR TITLE
feat: add Address trait to standardize content_addr()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ proc-macro2 = "1"
 quote = "1"
 rand = { version = "0.8", features = ["small_rng"] } # For VM tests.
 rayon = "1" # For `constraint-vm` parallelisation.
-schemars = "0.8.16"
+schemars = "0.8.21"
 secp256k1 = { version = "0.29", features = ["recovery"] }
 serde = { version = "1.0.195", features = ["derive"] }
 serde_yaml = "0.9"

--- a/crates/check/benches/check_contract.rs
+++ b/crates/check/benches/check_contract.rs
@@ -26,9 +26,7 @@ pub fn bench(c: &mut Criterion) {
         let (predicates, solution, predicates_map) = create(i);
         let get_predicate = |addr: &PredicateAddress| predicates_map.get(addr).cloned().unwrap();
         let mut pre_state = State::EMPTY;
-        pre_state.deploy_namespace(essential_hash::contract_addr::from_contract(
-            &predicates.contract,
-        ));
+        pre_state.deploy_namespace(essential_hash::content_addr(&predicates.contract));
         let mut post_state = pre_state.clone();
         post_state.apply_mutations(&solution);
         c.bench_function(&format!("check_42_{}", i), |b| {
@@ -65,7 +63,7 @@ fn create(
             (
                 PredicateAddress {
                     contract: contract.clone(),
-                    predicate: ContentAddress(essential_hash::hash(&predicate)),
+                    predicate: essential_hash::content_addr(predicate),
                 },
                 Arc::new(predicate.clone()),
             )
@@ -224,7 +222,7 @@ fn test_predicate_42(entropy: Word) -> Predicate {
 }
 
 fn contract_addr(contract: &SignedContract) -> ContentAddress {
-    essential_hash::contract_addr::from_contract(&contract.contract)
+    essential_hash::content_addr(&contract.contract)
 }
 
 fn random_keypair(seed: [u8; 32]) -> (SecretKey, PublicKey) {
@@ -250,9 +248,7 @@ fn test_predicate_42_solution_pair(
         .map(|i| SolutionData {
             predicate_to_solve: PredicateAddress {
                 contract: contract_addr.clone(),
-                predicate: ContentAddress(essential_hash::hash(
-                    signed_contract.contract.get(i).unwrap(),
-                )),
+                predicate: essential_hash::content_addr(signed_contract.contract.get(i).unwrap()),
             },
             decision_variables: vec![vec![42]],
             state_mutations: vec![Mutation {

--- a/crates/check/src/predicate.rs
+++ b/crates/check/src/predicate.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 #[cfg(feature = "tracing")]
-use essential_hash::contract_addr;
+use essential_hash::content_addr;
 use essential_types::contract;
 use thiserror::Error;
 
@@ -135,7 +135,7 @@ pub const MAX_DIRECTIVE_SIZE: usize = 1000;
 /// Validate a signed contract of predicates.
 ///
 /// Verifies the signature and then validates the contract.
-#[cfg_attr(feature = "tracing", tracing::instrument(skip_all, fields(addr = %contract_addr::from_contract(&signed_contract.contract)), err))]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all, fields(addr = %content_addr(&signed_contract.contract)), err))]
 pub fn check_signed_contract(
     signed_contract: &contract::SignedContract,
 ) -> Result<(), InvalidSignedContract> {

--- a/crates/check/src/solution.rs
+++ b/crates/check/src/solution.rs
@@ -213,7 +213,7 @@ impl<E: fmt::Display> fmt::Display for PredicateErrors<E> {
 /// its associated predicates.
 ///
 /// This includes solution data and state mutations.
-#[cfg_attr(feature = "tracing", tracing::instrument(skip_all, fields(solution = %content_addr(&solution.data)), err))]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all, fields(solution = %content_addr(solution)), err))]
 pub fn check(solution: &Solution) -> Result<(), InvalidSolution> {
     check_data(&solution.data)?;
     check_state_mutations(solution)?;

--- a/crates/check/tests/encoding.rs
+++ b/crates/check/tests/encoding.rs
@@ -75,7 +75,7 @@ async fn test_encoding_sig_and_pub_key() {
     let contract = Contract::without_salt(vec![predicate]);
 
     let address = PredicateAddress {
-        contract: essential_hash::contract_addr::from_contract(&contract),
+        contract: essential_hash::content_addr(&contract),
         predicate: essential_hash::content_addr(&contract[0]),
     };
 

--- a/crates/check/tests/solution.rs
+++ b/crates/check/tests/solution.rs
@@ -147,9 +147,7 @@ async fn check_predicate_42_with_solution() {
 
     // Construct the pre state, then apply mutations to acquire post state.
     let mut pre_state = State::EMPTY;
-    pre_state.deploy_namespace(essential_hash::contract_addr::from_contract(
-        &predicates.contract,
-    ));
+    pre_state.deploy_namespace(essential_hash::content_addr(&predicates.contract));
     let mut post_state = pre_state.clone();
     post_state.apply_mutations(&solution);
 
@@ -304,9 +302,7 @@ async fn predicate_with_multiple_state_reads_and_slots() {
 
     // Construct the pre state, then apply mutations to acquire post state.
     let mut pre_state = State::EMPTY;
-    pre_state.deploy_namespace(essential_hash::contract_addr::from_contract(
-        &predicates.contract,
-    ));
+    pre_state.deploy_namespace(essential_hash::content_addr(&predicates.contract));
     let mut post_state = pre_state.clone();
     post_state.apply_mutations(&solution);
 

--- a/crates/check/tests/util.rs
+++ b/crates/check/tests/util.rs
@@ -189,13 +189,13 @@ pub fn test_predicate_42(entropy: Word) -> Predicate {
 }
 
 pub fn contract_addr(predicates: &contract::SignedContract) -> ContentAddress {
-    essential_hash::contract_addr::from_contract(&predicates.contract)
+    essential_hash::content_addr(&predicates.contract)
 }
 
 pub fn predicate_addr(predicates: &contract::SignedContract, ix: usize) -> PredicateAddress {
     PredicateAddress {
         contract: contract_addr(predicates),
-        predicate: ContentAddress(essential_hash::hash(&predicates.contract[ix])),
+        predicate: essential_hash::content_addr(&predicates.contract[ix]),
     }
 }
 

--- a/crates/hash/src/address_impl.rs
+++ b/crates/hash/src/address_impl.rs
@@ -2,7 +2,7 @@ use essential_types::{
     contract::Contract, predicate::Predicate, solution::Solution, Block, ContentAddress,
 };
 
-use crate::Address;
+use crate::{hash, Address};
 
 impl Address for Block {
     fn content_address(&self) -> ContentAddress {
@@ -10,7 +10,11 @@ impl Address for Block {
     }
 }
 
-impl Address for Predicate {}
+impl Address for Predicate {
+    fn content_address(&self) -> ContentAddress {
+        ContentAddress(hash(self))
+    }
+}
 
 impl Address for Contract {
     fn content_address(&self) -> ContentAddress {
@@ -18,4 +22,8 @@ impl Address for Contract {
     }
 }
 
-impl Address for Solution {}
+impl Address for Solution {
+    fn content_address(&self) -> ContentAddress {
+        ContentAddress(hash(self))
+    }
+}

--- a/crates/hash/src/address_impl.rs
+++ b/crates/hash/src/address_impl.rs
@@ -1,0 +1,21 @@
+use essential_types::{
+    contract::Contract, predicate::Predicate, solution::Solution, Block, ContentAddress,
+};
+
+use crate::Address;
+
+impl Address for Block {
+    fn content_address(&self) -> ContentAddress {
+        crate::block_addr::from_block(self)
+    }
+}
+
+impl Address for Predicate {}
+
+impl Address for Contract {
+    fn content_address(&self) -> ContentAddress {
+        crate::contract_addr::from_contract(self)
+    }
+}
+
+impl Address for Solution {}

--- a/crates/hash/src/block_addr.rs
+++ b/crates/hash/src/block_addr.rs
@@ -1,4 +1,4 @@
-//! A small collection of helper functions to assist in the calculation of an
+//! A small collection of helper functions to assist in the calculation of a
 //! block's content address.
 //!
 //! Note that it is possible this hash will change in the future
@@ -6,7 +6,7 @@
 
 use essential_types::{Block, ContentAddress};
 
-/// Shorthand for the common case of producing an block's content address
+/// Shorthand for the common case of producing a block's content address
 /// from a [`Block`].
 ///
 /// *Note:* this also hashes each solution.

--- a/crates/hash/src/block_addr.rs
+++ b/crates/hash/src/block_addr.rs
@@ -1,0 +1,53 @@
+//! A small collection of helper functions to assist in the calculation of an
+//! block's content address.
+//!
+//! Note that it is possible this hash will change in the future
+//! if merkle proofs or a header type is introduced.
+
+use essential_types::{Block, ContentAddress};
+
+/// Shorthand for the common case of producing an block's content address
+/// from a [`Block`].
+///
+/// *Note:* this also hashes each solution.
+/// If you already have the content address for each solution consider
+/// using [`from_block_and_solutions_addrs`] or [`from_block_and_solutions_addrs_slice`].
+pub fn from_block(block: &Block) -> ContentAddress {
+    let solution_addrs = block.solutions.iter().map(crate::content_addr);
+    from_block_and_solutions_addrs(block, solution_addrs)
+}
+
+/// Given the content address for each solution in the block, produce the
+/// block's content address.
+///
+/// *Warning:* the caller **must** ensure that the order of the solutions
+/// matches the order of the solutions in the block.
+/// Otherwise the content address will be different then the one calculated
+/// for the [`Block`].
+pub fn from_block_and_solutions_addrs(
+    block: &Block,
+    solution_addrs: impl IntoIterator<Item = ContentAddress>,
+) -> ContentAddress {
+    let solution_addrs: Vec<ContentAddress> = solution_addrs.into_iter().collect();
+    from_block_and_solutions_addrs_slice(block, &solution_addrs)
+}
+
+/// Given the content address for each solution in the block, produce the
+/// block's content address.
+///
+/// *Warning:* the caller **must** ensure that the order of the solutions
+/// matches the order of the solutions in the block.
+/// Otherwise the content address will be different then the one calculated
+/// for the [`Block`].
+pub fn from_block_and_solutions_addrs_slice(
+    block: &Block,
+    solution_addrs: &[ContentAddress],
+) -> ContentAddress {
+    let Block {
+        number,
+        timestamp,
+        solutions: _,
+    } = block;
+    let header = (number, timestamp, solution_addrs);
+    ContentAddress(crate::hash(&header))
+}

--- a/crates/hash/src/contract_addr.rs
+++ b/crates/hash/src/contract_addr.rs
@@ -43,5 +43,5 @@ pub fn from_predicate_addrs_slice(
     salt: &Hash,
 ) -> ContentAddress {
     predicate_addrs.sort();
-    crate::content_addr(&(predicate_addrs, salt))
+    ContentAddress(crate::hash(&(predicate_addrs, salt)))
 }

--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -14,11 +14,9 @@ pub mod contract_addr;
 
 /// Standardized trait for creating content addresses for
 /// types using the correct constructors.
-pub trait Address: Serialize {
+pub trait Address {
     /// Produce the content address for self.
-    fn content_address(&self) -> ContentAddress {
-        ContentAddress(hash(&self))
-    }
+    fn content_address(&self) -> ContentAddress;
 }
 
 /// Serialize data for hashing using postcard.

--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -8,7 +8,18 @@ use essential_types::{convert::bytes_from_word, ContentAddress, Hash, Word};
 use serde::Serialize;
 use sha2::Digest;
 
+mod address_impl;
+pub mod block_addr;
 pub mod contract_addr;
+
+/// Standardized trait for creating content addresses for
+/// types using the correct constructors.
+pub trait Address: Serialize {
+    /// Produce the content address for self.
+    fn content_address(&self) -> ContentAddress {
+        ContentAddress(hash(&self))
+    }
+}
 
 /// Serialize data for hashing using postcard.
 ///
@@ -33,8 +44,8 @@ pub fn hash<T: Serialize>(t: &T) -> Hash {
 /// Shorthand for hashing the given value in order to produce its content address.
 ///
 /// Commonly useful for solutions, predicates and contracts.
-pub fn content_addr<T: Serialize>(t: &T) -> ContentAddress {
-    ContentAddress(hash(t))
+pub fn content_addr<T: Address>(t: &T) -> ContentAddress {
+    t.content_address()
 }
 
 /// Hash words in the same way that `Crypto::Sha256` does.

--- a/crates/hash/tests/hash.rs
+++ b/crates/hash/tests/hash.rs
@@ -1,4 +1,9 @@
-use essential_types::predicate::{Directive, Predicate};
+use essential_types::{
+    contract::Contract,
+    predicate::{Directive, Predicate},
+    solution::{Solution, SolutionData},
+    Block, ContentAddress, PredicateAddress,
+};
 
 fn test_predicate() -> Predicate {
     Predicate {
@@ -22,4 +27,61 @@ fn hash_predicate() {
     let expected_hash_hex = "709e80c88487a2411e1ee4dfb9f22a861492d20c4765150c0c794abd70f8147c";
     let hex = hex::encode(hash);
     assert_eq!(hex, expected_hash_hex);
+}
+
+#[test]
+fn test_content_addr() {
+    let addr = essential_hash::hash(&test_predicate());
+    let content_addr = essential_hash::content_addr(&test_predicate());
+    assert_eq!(content_addr.0, addr);
+
+    let contract = Contract {
+        salt: Default::default(),
+        predicates: vec![test_predicate()],
+    };
+    let addr = essential_hash::contract_addr::from_contract(&contract);
+    let content_addr = essential_hash::content_addr(&contract);
+    assert_eq!(content_addr, addr);
+
+    let solution = Solution { data: vec![] };
+    let addr = essential_hash::hash(&solution);
+    let content_addr = essential_hash::content_addr(&solution);
+    assert_eq!(content_addr.0, addr);
+
+    let solutions = vec![
+        Solution {
+            data: vec![SolutionData {
+                predicate_to_solve: PredicateAddress {
+                    contract: ContentAddress([1; 32]),
+                    predicate: ContentAddress([1; 32]),
+                },
+                decision_variables: Default::default(),
+                transient_data: Default::default(),
+                state_mutations: Default::default(),
+            }],
+        },
+        Solution {
+            data: vec![SolutionData {
+                predicate_to_solve: PredicateAddress {
+                    contract: ContentAddress([2; 32]),
+                    predicate: ContentAddress([2; 32]),
+                },
+                decision_variables: Default::default(),
+                transient_data: Default::default(),
+                state_mutations: Default::default(),
+            }],
+        },
+    ];
+    let block = Block {
+        number: 0,
+        timestamp: core::time::Duration::from_secs(0),
+        solutions: solutions.clone(),
+    };
+    let addr = essential_hash::block_addr::from_block(&block);
+    let content_addr = essential_hash::content_addr(&block);
+    assert_eq!(content_addr, addr);
+
+    let solution_addrs = solutions.iter().rev().map(essential_hash::content_addr);
+    let addr = essential_hash::block_addr::from_block_and_solutions_addrs(&block, solution_addrs);
+    assert_ne!(content_addr, addr);
 }

--- a/crates/sign/src/contract.rs
+++ b/crates/sign/src/contract.rs
@@ -21,7 +21,7 @@ use secp256k1::{PublicKey, SecretKey};
 /// the content address directly with [`sign_hash`][crate::sign_hash] and then
 /// constructing the [`predicate::SignedContract`] from its fields.
 pub fn sign(contract: Contract, sk: &SecretKey) -> contract::SignedContract {
-    let ca = essential_hash::contract_addr::from_contract(&contract);
+    let ca = essential_hash::content_addr(&contract);
     let signature = crate::sign_hash(ca.0, sk);
     contract::SignedContract {
         contract,
@@ -31,7 +31,7 @@ pub fn sign(contract: Contract, sk: &SecretKey) -> contract::SignedContract {
 
 /// Verifies the signature against the content address of the contract.
 pub fn verify(signed: &contract::SignedContract) -> Result<(), secp256k1::Error> {
-    let ca = essential_hash::contract_addr::from_contract(&signed.contract);
+    let ca = essential_hash::content_addr(&signed.contract);
     crate::verify_hash(ca.0, &signed.signature)
 }
 
@@ -43,6 +43,6 @@ pub fn verify(signed: &contract::SignedContract) -> Result<(), secp256k1::Error>
 /// If the content address of the contract is already known, consider recovering the
 /// content address directly.
 pub fn recover(signed: &contract::SignedContract) -> Result<PublicKey, secp256k1::Error> {
-    let ca = essential_hash::contract_addr::from_contract(&signed.contract);
+    let ca = essential_hash::content_addr(&signed.contract);
     crate::recover_hash(ca.0, &signed.signature)
 }


### PR DESCRIPTION
closes https://github.com/essential-contributions/essential-node/issues/39

Adds the `Address` trait so that the `essential_hash::content_addr()` function will always produce the correct hash.