### PR TITLE
feat: encode predicate and hash

### DIFF
--- a/crates/check/src/predicate.rs
+++ b/crates/check/src/predicate.rs
@@ -58,7 +58,7 @@ pub fn check_contract(predicates: &[Predicate]) -> Result<(), InvalidContract> {
 
 /// Validate a single predicate.
 ///
-/// Validates the slots, directive, state reads, and constraints.
+/// Validates the slots, state reads, and constraints.
 pub fn check(predicate: &Predicate) -> Result<(), PredicateError> {
     predicate.check_predicate_bounds()?;
     Ok(())

--- a/crates/check/src/predicate.rs
+++ b/crates/check/src/predicate.rs
@@ -1,12 +1,9 @@
 //! Items related to the validation of [`Predicate`]s.
 
-use crate::{
-    sign::secp256k1,
-    types::{predicate::Predicate, ConstraintBytecode, StateReadBytecode},
-};
+use crate::{sign::secp256k1, types::predicate::Predicate};
 #[cfg(feature = "tracing")]
 use essential_hash::content_addr;
-use essential_types::contract;
+use essential_types::{contract, predicate::header::PredicateError};
 use thiserror::Error;
 
 /// [`check_signed_contract`] error.
@@ -28,74 +25,11 @@ pub enum InvalidContract {
     TooManyPredicates(usize),
     /// The predicate at the given index was invalid.
     #[error("predicate at index {0} is invalid: {1}")]
-    Predicate(usize, InvalidPredicate),
-}
-
-/// [`check`] error indicating part of a predicate was invalid.
-#[derive(Debug, Error)]
-pub enum InvalidPredicate {
-    /// The predicate's state reads are invalid.
-    #[error("invalid state reads: {0}")]
-    StateReads(#[from] InvalidStateReads),
-    /// The predicate's constraints are invalid.
-    #[error("invalid constraints: {0}")]
-    Constraints(#[from] InvalidConstraints),
-}
-
-/// [`check_state_reads`] error.
-#[derive(Debug, Error)]
-pub enum InvalidStateReads {
-    /// The number of state reads exceeds the limit.
-    #[error("the number of state reads ({0}) exceeds the limit ({MAX_STATE_READS})")]
-    TooMany(usize),
-    /// The state read at the given index failed to validate.
-    #[error("state read at index {0} failed to validate: {1}")]
-    StateRead(usize, InvalidStateRead),
-}
-
-/// [`check_state_read`] error.
-#[derive(Debug, Error)]
-pub enum InvalidStateRead {
-    /// The length of the bytecode exceeds the limit.
-    #[error("the length of the bytecode ({0}) exceeds the limit ({MAX_STATE_READ_SIZE_IN_BYTES}")]
-    TooManyBytes(usize),
-}
-
-/// [`check_constraints`] error.
-#[derive(Debug, Error)]
-pub enum InvalidConstraints {
-    /// The number of constraints exceeds the limit.
-    #[error("the number of constraints ({0}) exceeds the limit ({MAX_CONSTRAINTS})")]
-    TooManyConstraints(usize),
-    /// The constraint at the given index failed to validate.
-    #[error("constraint at index {0} failed to validate: {1}")]
-    Constraint(usize, InvalidConstraint),
-}
-
-/// [`check_constraint`] error.
-#[derive(Debug, Error)]
-pub enum InvalidConstraint {
-    /// The length of the bytecode exceeds the limit.
-    #[error("the length of the bytecode ({0}) exceeds the limit ({MAX_CONSTRAINT_SIZE_IN_BYTES}")]
-    TooManyBytes(usize),
+    Predicate(usize, PredicateError),
 }
 
 /// Maximum number of predicates in a contract.
 pub const MAX_PREDICATES: usize = 100;
-/// Maximum number of state read programs of a predicate.
-pub const MAX_STATE_READS: usize = 100;
-/// Maximum size of state read programs of a predicate in bytes.
-pub const MAX_STATE_READ_SIZE_IN_BYTES: usize = 10_000;
-/// Maximum number of constraint check programs of a predicate.
-pub const MAX_CONSTRAINTS: usize = 100;
-/// Maximum size of constraint check programs of a predicate in bytes.
-pub const MAX_CONSTRAINT_SIZE_IN_BYTES: usize = 10_000;
-/// Maximum number of decision variables of the slots of a predicate.
-pub const MAX_DECISION_VARIABLES: u32 = 100;
-/// Maximum number of state slots of a predicate.
-pub const MAX_NUM_STATE_SLOTS: usize = 1000;
-/// Maximum length of state slots of a predicate.
-pub const MAX_STATE_LEN: u32 = 1000;
 
 /// Validate a signed contract of predicates.
 ///
@@ -124,47 +58,8 @@ pub fn check_contract(predicates: &[Predicate]) -> Result<(), InvalidContract> {
 
 /// Validate a single predicate.
 ///
-/// Validates the slots, state reads, and constraints.
-pub fn check(predicate: &Predicate) -> Result<(), InvalidPredicate> {
-    check_state_reads(&predicate.state_read)?;
-    check_constraints(&predicate.constraints)?;
-    Ok(())
-}
-
-/// Validate a predicate's state read bytecode.
-pub fn check_state_reads(state_reads: &[StateReadBytecode]) -> Result<(), InvalidStateReads> {
-    if state_reads.len() > MAX_STATE_READS {
-        return Err(InvalidStateReads::TooMany(state_reads.len()));
-    }
-    for (ix, state_read) in state_reads.iter().enumerate() {
-        check_state_read(state_read).map_err(|e| InvalidStateReads::StateRead(ix, e))?;
-    }
-    Ok(())
-}
-
-/// Validate a single state read bytecode slice.
-pub fn check_state_read(state_read: &[u8]) -> Result<(), InvalidStateRead> {
-    if state_read.len() > MAX_STATE_READ_SIZE_IN_BYTES {
-        return Err(InvalidStateRead::TooManyBytes(state_read.len()));
-    }
-    Ok(())
-}
-
-/// Validate a predicate's constraint bytecode.
-pub fn check_constraints(constraints: &[ConstraintBytecode]) -> Result<(), InvalidConstraints> {
-    if constraints.len() > MAX_CONSTRAINTS {
-        return Err(InvalidConstraints::TooManyConstraints(constraints.len()));
-    }
-    for (ix, constraint) in constraints.iter().enumerate() {
-        check_constraint(constraint).map_err(|e| InvalidConstraints::Constraint(ix, e))?;
-    }
-    Ok(())
-}
-
-/// Validate a single constraint bytecode slice.
-pub fn check_constraint(constraint: &[u8]) -> Result<(), InvalidConstraint> {
-    if constraint.len() > MAX_CONSTRAINT_SIZE_IN_BYTES {
-        return Err(InvalidConstraint::TooManyBytes(constraint.len()));
-    }
+/// Validates the slots, directive, state reads, and constraints.
+pub fn check(predicate: &Predicate) -> Result<(), PredicateError> {
+    predicate.check_predicate_bounds()?;
     Ok(())
 }

--- a/crates/check/tests/predicate.rs
+++ b/crates/check/tests/predicate.rs
@@ -1,4 +1,5 @@
 use essential_check::predicate;
+use essential_types::predicate::{header::PredicateError, Predicate};
 use util::{empty_predicate, random_keypair};
 
 pub mod util;
@@ -36,43 +37,43 @@ fn too_many_predicates() {
 #[test]
 fn too_many_state_reads() {
     let mut predicate = empty_predicate();
-    predicate.state_read = vec![vec![]; predicate::MAX_STATE_READS + 1];
+    predicate.state_read = vec![vec![]; Predicate::MAX_STATE_READS + 1];
     assert!(matches!(
         predicate::check(&predicate).unwrap_err(),
-        predicate::InvalidPredicate::StateReads(predicate::InvalidStateReads::TooMany(n))
-            if n == predicate::MAX_STATE_READS + 1
+        PredicateError::TooManyStateReads(n)
+            if n == Predicate::MAX_STATE_READS + 1
     ));
 }
 
 #[test]
 fn state_read_too_large() {
     let mut predicate = empty_predicate();
-    predicate.state_read = vec![vec![0u8; predicate::MAX_STATE_READ_SIZE_IN_BYTES + 1]];
+    predicate.state_read = vec![vec![0u8; Predicate::MAX_STATE_READ_SIZE_BYTES + 1]];
     assert!(matches!(
         predicate::check(&predicate).unwrap_err(),
-        predicate::InvalidPredicate::StateReads(predicate::InvalidStateReads::StateRead(0, predicate::InvalidStateRead::TooManyBytes(n)))
-            if n == predicate::MAX_STATE_READ_SIZE_IN_BYTES + 1
+        PredicateError::StateReadTooLarge(n)
+            if n == Predicate::MAX_STATE_READ_SIZE_BYTES + 1
     ));
 }
 
 #[test]
 fn too_many_constraints() {
     let mut predicate = empty_predicate();
-    predicate.constraints = vec![vec![]; predicate::MAX_CONSTRAINTS + 1];
+    predicate.constraints = vec![vec![]; Predicate::MAX_CONSTRAINTS + 1];
     assert!(matches!(
         predicate::check(&predicate).unwrap_err(),
-        predicate::InvalidPredicate::Constraints(predicate::InvalidConstraints::TooManyConstraints(n))
-            if n == predicate::MAX_CONSTRAINTS + 1
+        PredicateError::TooManyConstraints(n)
+            if n == Predicate::MAX_CONSTRAINTS + 1
     ));
 }
 
 #[test]
 fn constraint_too_large() {
     let mut predicate = empty_predicate();
-    predicate.constraints = vec![vec![0u8; predicate::MAX_CONSTRAINT_SIZE_IN_BYTES + 1]];
+    predicate.constraints = vec![vec![0u8; Predicate::MAX_CONSTRAINT_SIZE_BYTES + 1]];
     assert!(matches!(
         predicate::check(&predicate).unwrap_err(),
-        predicate::InvalidPredicate::Constraints(predicate::InvalidConstraints::Constraint(0, predicate::InvalidConstraint::TooManyBytes(n)))
-            if n == predicate::MAX_CONSTRAINT_SIZE_IN_BYTES + 1
+        PredicateError::ConstraintTooLarge(n)
+            if n == Predicate::MAX_CONSTRAINT_SIZE_BYTES + 1
     ));
 }

--- a/crates/hash/src/address_impl.rs
+++ b/crates/hash/src/address_impl.rs
@@ -20,7 +20,7 @@ impl Address for Predicate {
         let mut hasher = <sha2::Sha256 as sha2::Digest>::new();
         hasher.update(header.fixed_size_header.0);
         hasher.update(header.lens);
-        for item in self.as_programs() {
+        for item in self.programs() {
             hasher.update(item);
         }
         ContentAddress(hasher.finalize().into())

--- a/crates/hash/src/address_impl.rs
+++ b/crates/hash/src/address_impl.rs
@@ -17,9 +17,9 @@ impl Address for Predicate {
             return ContentAddress([0; 32]);
         };
         let mut hasher = <sha2::Sha256 as sha2::Digest>::new();
-        hasher.update(header.static_header.0);
+        hasher.update(header.fixed_size_header.0);
         hasher.update(header.lens);
-        for item in self.programs() {
+        for item in self.as_programs() {
             hasher.update(item);
         }
         ContentAddress(hasher.finalize().into())

--- a/crates/hash/src/address_impl.rs
+++ b/crates/hash/src/address_impl.rs
@@ -1,6 +1,7 @@
 use essential_types::{
     contract::Contract, predicate::Predicate, solution::Solution, Block, ContentAddress,
 };
+use sha2::Digest;
 
 use crate::{hash, Address};
 

--- a/crates/hash/tests/hash.rs
+++ b/crates/hash/tests/hash.rs
@@ -36,7 +36,7 @@ fn test_content_addr() {
     let mut hasher = <sha2::Sha256 as sha2::Digest>::new();
     hasher.update(header.fixed_size_header.0);
     hasher.update(header.lens);
-    for item in pred.as_programs() {
+    for item in pred.programs() {
         hasher.update(item);
     }
     let addr = ContentAddress(hasher.finalize().into());

--- a/crates/hash/tests/hash.rs
+++ b/crates/hash/tests/hash.rs
@@ -4,6 +4,7 @@ use essential_types::{
     solution::{Solution, SolutionData},
     Block, ContentAddress, PredicateAddress,
 };
+use sha2::Digest;
 
 fn test_predicate() -> Predicate {
     Predicate {
@@ -30,9 +31,17 @@ fn hash_predicate() {
 
 #[test]
 fn test_content_addr() {
-    let addr = essential_hash::hash(&test_predicate());
+    let pred = &test_predicate();
+    let header = pred.encoded_header().unwrap();
+    let mut hasher = <sha2::Sha256 as sha2::Digest>::new();
+    hasher.update(header.fixed_size_header.0);
+    hasher.update(header.lens);
+    for item in pred.as_programs() {
+        hasher.update(item);
+    }
+    let addr = ContentAddress(hasher.finalize().into());
     let content_addr = essential_hash::content_addr(&test_predicate());
-    assert_eq!(content_addr.0, addr);
+    assert_eq!(content_addr, addr);
 
     let contract = Contract {
         salt: Default::default(),

--- a/crates/sign/tests/sign.rs
+++ b/crates/sign/tests/sign.rs
@@ -22,8 +22,8 @@ fn sign_predicate() {
     let contract = Contract::without_salt(vec![test_predicate()]);
     let signed = sign(contract, &sk);
     let expected_signature_hex = concat!(
-        "60d57533ecbcd6c7cbf462e5944cbd4aef416c2f5587b024dc800be9c6ace81d",
-        "1c2ad24bab4af6814394a32ff9023472171e98e59ce2561f44d16694f5306b41"
+        "b9c3a75deb001657b7c88d0e373cdcee7d1bf79b6f225d5d174e1a542f9ae6b8",
+        "566806889f00dd97770c76c45641765d8a1bbd55d8057463af754981b8891153"
     );
     let hex = hex::encode(signed.signature.0);
     assert_eq!(expected_signature_hex, hex);

--- a/crates/sign/tests/sign.rs
+++ b/crates/sign/tests/sign.rs
@@ -22,8 +22,8 @@ fn sign_predicate() {
     let contract = Contract::without_salt(vec![test_predicate()]);
     let signed = sign(contract, &sk);
     let expected_signature_hex = concat!(
-        "b9c3a75deb001657b7c88d0e373cdcee7d1bf79b6f225d5d174e1a542f9ae6b8",
-        "566806889f00dd97770c76c45641765d8a1bbd55d8057463af754981b8891153"
+        "60d57533ecbcd6c7cbf462e5944cbd4aef416c2f5587b024dc800be9c6ace81d",
+        "1c2ad24bab4af6814394a32ff9023472171e98e59ce2561f44d16694f5306b41"
     );
     let hex = hex::encode(signed.signature.0);
     assert_eq!(expected_signature_hex, hex);

--- a/crates/types/src/contract.rs
+++ b/crates/types/src/contract.rs
@@ -43,6 +43,9 @@ pub struct Contract {
 }
 
 impl Contract {
+    /// Maximum number of predicates in a contract.
+    pub const MAX_PREDICATES: usize = 100;
+
     /// Create a new contract with the given predicates but no salt.
     pub fn without_salt(predicates: Vec<Predicate>) -> Self {
         Self {

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -33,9 +33,6 @@ pub type Value = Vec<Word>;
 /// Hash encoded as a 32 byte array.
 pub type Hash = [u8; 32];
 
-/// Externally owned account.
-pub type Eoa = [u8; 32];
-
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Recoverable ECDSA signature over some data.
 pub struct Signature(

--- a/crates/types/src/predicate.rs
+++ b/crates/types/src/predicate.rs
@@ -1,14 +1,17 @@
 //! # Predicates
 //! Types needed to represent a predicate.
 
-use std::f32::consts::E;
-
 use crate::{serde::bytecode, ConstraintBytecode, StateReadBytecode};
 use header::{check_predicate_bounds, encoded_size, EncodedSize, PredicateBounds, PredicateError};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
+
+#[cfg(test)]
+mod tests;
+
+pub mod header;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -40,10 +43,10 @@ impl Predicate {
     /// Maximum size of directive of a predicate.
     pub const MAX_DIRECTIVE_SIZE_BYTES: usize = 1000;
     /// Maximum size of a predicate in bytes.
-    pub const MAX_PREDICATE_BYTES: usize = 1024 * 50;
+    pub const MAX_BYTES: usize = 1024 * 50;
 
     /// Iterator over the programs in the predicate.
-    pub fn programs(&self) -> impl Iterator<Item = &[u8]> {
+    pub fn as_programs(&self) -> impl Iterator<Item = &[u8]> {
         self.state_read
             .iter()
             .chain(self.constraints.iter())
@@ -65,16 +68,28 @@ impl Predicate {
         let header = self.encoded_header()?;
         Ok(header
             .into_iter()
-            .chain(self.programs().flat_map(|x| x.iter().copied())))
+            .chain(self.as_programs().flat_map(|x| x.iter().copied())))
     }
 
     /// The size of the encoded predicate in bytes.
+    ///
+    /// This uses [`usize::saturating_add`] to sum the
+    /// lengths of the state read and constraint.
+    /// This could lead to an incorrect size for a
+    /// very large predicate. However, such a predicate
+    /// would be invalid due to the size limits.
     pub fn encoded_size(&self) -> usize {
         let sizes = EncodedSize {
             num_state_reads: self.state_read.len(),
             num_constraints: self.constraints.len(),
-            state_read_lens_sum: self.state_read.iter().map(|x| x.len()).sum::<usize>(),
-            constraint_lens_sum: self.constraints.iter().map(|x| x.len()).sum::<usize>(),
+            state_read_lens_sum: self
+                .state_read
+                .iter()
+                .fold(0, |i, p| i.saturating_add(p.len())),
+            constraint_lens_sum: self
+                .constraints
+                .iter()
+                .fold(0, |i, p| i.saturating_add(p.len())),
         };
         encoded_size(&sizes)
     }

--- a/crates/types/src/predicate.rs
+++ b/crates/types/src/predicate.rs
@@ -97,7 +97,17 @@ impl Predicate {
     /// Decode a predicate from bytes.
     pub fn decode<B: AsRef<[u8]>>(bytes: B) -> Result<Self, header::DecodeError> {
         let bytes = bytes.as_ref();
+
+        // Decode the header.
         let header = header::DecodedHeader::decode(bytes)?;
+
+        // Check the buffer is large enough to hold
+        // the data that the header is pointing to.
+        if bytes.len() < header.bytes_len() {
+            return Err(header::DecodeError::BufferTooSmall);
+        }
+
+        // Decode the programs.
         let state_read = header.decode_state_read(bytes);
         let constraints = header.decode_constraints(bytes);
         Ok(Self {

--- a/crates/types/src/predicate.rs
+++ b/crates/types/src/predicate.rs
@@ -40,8 +40,6 @@ impl Predicate {
     pub const MAX_CONSTRAINTS: usize = u8::MAX as usize;
     /// Maximum size of constraint check programs of a predicate in bytes.
     pub const MAX_CONSTRAINT_SIZE_BYTES: usize = 10_000;
-    /// Maximum size of directive of a predicate.
-    pub const MAX_DIRECTIVE_SIZE_BYTES: usize = 1000;
     /// Maximum size of a predicate in bytes.
     pub const MAX_BYTES: usize = 1024 * 50;
 
@@ -123,7 +121,6 @@ impl Predicate {
             num_constraints: self.constraints.len(),
             state_read_lens: self.state_read.iter().map(|x| x.len()),
             constraint_lens: self.constraints.iter().map(|x| x.len()),
-            directive_size: self.directive.as_program().map_or(0, |x| x.len()),
         };
         check_predicate_bounds(bounds)
     }

--- a/crates/types/src/predicate.rs
+++ b/crates/types/src/predicate.rs
@@ -1,7 +1,10 @@
 //! # Predicates
 //! Types needed to represent a predicate.
 
+use std::f32::consts::E;
+
 use crate::{serde::bytecode, ConstraintBytecode, StateReadBytecode};
+use header::{check_predicate_bounds, encoded_size, EncodedSize, PredicateBounds, PredicateError};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "schema")]
@@ -23,4 +26,80 @@ pub struct Predicate {
         deserialize_with = "bytecode::deserialize_vec"
     )]
     pub constraints: Vec<ConstraintBytecode>,
+}
+
+impl Predicate {
+    /// Maximum number of state read programs of a predicate.
+    pub const MAX_STATE_READS: usize = u8::MAX as usize;
+    /// Maximum size of state read programs of a predicate in bytes.
+    pub const MAX_STATE_READ_SIZE_BYTES: usize = 10_000;
+    /// Maximum number of constraint check programs of a predicate.
+    pub const MAX_CONSTRAINTS: usize = u8::MAX as usize;
+    /// Maximum size of constraint check programs of a predicate in bytes.
+    pub const MAX_CONSTRAINT_SIZE_BYTES: usize = 10_000;
+    /// Maximum size of directive of a predicate.
+    pub const MAX_DIRECTIVE_SIZE_BYTES: usize = 1000;
+    /// Maximum size of a predicate in bytes.
+    pub const MAX_PREDICATE_BYTES: usize = 1024 * 50;
+
+    /// Iterator over the programs in the predicate.
+    pub fn programs(&self) -> impl Iterator<Item = &[u8]> {
+        self.state_read
+            .iter()
+            .chain(self.constraints.iter())
+            .map(|x| x.as_slice())
+    }
+
+    /// An owning Iterator over the programs in the predicate.
+    pub fn into_programs(self) -> impl Iterator<Item = Vec<u8>> {
+        self.state_read.into_iter().chain(self.constraints)
+    }
+
+    /// Generate the encoding header for this predicate.
+    pub fn encoded_header(&self) -> Result<header::EncodedHeader, PredicateError> {
+        (self).try_into()
+    }
+
+    /// Encode the predicate into a bytes iterator.
+    pub fn encode(&self) -> Result<impl Iterator<Item = u8> + '_, PredicateError> {
+        let header = self.encoded_header()?;
+        Ok(header
+            .into_iter()
+            .chain(self.programs().flat_map(|x| x.iter().copied())))
+    }
+
+    /// The size of the encoded predicate in bytes.
+    pub fn encoded_size(&self) -> usize {
+        let sizes = EncodedSize {
+            num_state_reads: self.state_read.len(),
+            num_constraints: self.constraints.len(),
+            state_read_lens_sum: self.state_read.iter().map(|x| x.len()).sum::<usize>(),
+            constraint_lens_sum: self.constraints.iter().map(|x| x.len()).sum::<usize>(),
+        };
+        encoded_size(&sizes)
+    }
+
+    /// Decode a predicate from bytes.
+    pub fn decode<B: AsRef<[u8]>>(bytes: B) -> Result<Self, header::DecodeError> {
+        let bytes = bytes.as_ref();
+        let header = header::DecodedHeader::decode(bytes)?;
+        let state_read = header.decode_state_read(bytes);
+        let constraints = header.decode_constraints(bytes);
+        Ok(Self {
+            state_read,
+            constraints,
+        })
+    }
+
+    /// Check the predicate is within the limits of a valid predicate.
+    pub fn check_predicate_bounds(&self) -> Result<(), PredicateError> {
+        let bounds = PredicateBounds {
+            num_state_reads: self.state_read.len(),
+            num_constraints: self.constraints.len(),
+            state_read_lens: self.state_read.iter().map(|x| x.len()),
+            constraint_lens: self.constraints.iter().map(|x| x.len()),
+            directive_size: self.directive.as_program().map_or(0, |x| x.len()),
+        };
+        check_predicate_bounds(bounds)
+    }
 }

--- a/crates/types/src/predicate/header.rs
+++ b/crates/types/src/predicate/header.rs
@@ -1,0 +1,573 @@
+//! # Predicate Encoding Headers
+//!
+//! This module contains the encoding and decoding logic for the header of a
+//! [`Predicate`] when encoding to bytes.
+//! This encoding is used to hash the predicate.
+//!
+//! ## Encoding
+//! This table describes the encoding of a `Predicate` to bytes. \
+//! Bytes are encoded starting at the first row and moving down. \
+//! Anything larger than a byte is encoded in big-endian. \
+//! Lengths are all unsigned integers.
+//!
+//! | Field | Size | Description |
+//! | --- | --- | --- |
+//! | [`num_state_reads`] | 1 byte | [`length`] of [`state_read`] |
+//! | [`num_constraints`] | 1 byte | [`length`] of [`constraints`] |
+//! | [`directive_tag`] | 1 byte | [`Directive`] variant as [`DirectiveTag`] |
+//! | [`directive_len`] | 2 bytes | length of the [`Directive::Maximize`] or [`Directive::Minimize`] program or `0` |
+//! | [`Len`] of each [`StateReadBytecode`]| 2 bytes * [`num_state_reads`] | length of each [`state_read`] program |
+//! | [`Len`] of each [`ConstraintBytecode`]| 2 bytes * [`num_constraints`] | length of each [`constraints`] program |
+//! | each [`StateReadBytecode`] | [`length`] of each [`StateReadBytecode`] * [`num_state_reads`] | bytes of each [`state_read`] program |
+//! | each [`ConstraintBytecode`] | [`length`] of each [`ConstraintBytecode`] * [`num_constraints`] | bytes of each [`constraints`] program |
+//!
+//! ## Hashing
+//! The hash of the predicate is as follows:
+//! 1. Hash the bytes of the static part of the header.
+//! 2. Hash the bytes of the lens part of the header.
+//! 3. Hash the bytes of each [`Predicate::programs`] in the predicate
+//! (in the order of the iterator).
+//!
+//! [`num_state_reads`]: StaticHeaderLayout::num_state_reads
+//! [`num_constraints`]: StaticHeaderLayout::num_constraints
+//! [`directive_tag`]: StaticHeaderLayout::directive_tag
+//! [`directive_len`]: StaticHeaderLayout::directive_len
+//!
+//! [`state_read`]: Predicate::state_read
+//! [`constraints`]: Predicate::constraints
+//! [`StateReadBytecode`]: super::StateReadBytecode
+//! [`ConstraintBytecode`]: super::ConstraintBytecode
+//!
+//! [`length`]: Vec::len
+
+use super::{Directive, Predicate};
+use core::num::TryFromIntError;
+use error::DecodeResult;
+
+pub use error::DecodeError;
+pub use error::PredicateError;
+
+mod error;
+#[cfg(test)]
+mod tests;
+
+/// The encoded [`Predicate`] header.
+///
+/// This encodes the structure of the [`Predicate`] when encoding to bytes.
+pub struct EncodedHeader {
+    /// The static part of the header.
+    pub static_header: StaticHeader,
+    /// The dynamic lengths part of the header.
+    pub lens: Vec<u8>,
+}
+
+/// Layout of the static part of the header.
+pub struct StaticHeaderLayout {
+    /// Number of state reads.
+    /// This must fit in a `u8`.
+    pub num_state_reads: u8,
+    /// Number of constraints.
+    /// This must fit in a `u8`.
+    pub num_constraints: u8,
+    /// Tag of the directive.
+    /// Encoded as a `u8`.
+    pub directive_tag: DirectiveTag,
+    /// Length of the directive program.
+    /// This must fit in a `u16`.
+    ///
+    /// When encoding to bytes this will be encoded as two big-endian bytes.
+    pub directive_len: u16,
+}
+
+pub struct DecodedHeader {
+    pub state_reads: Vec<core::ops::Range<usize>>,
+    pub constraints: Vec<core::ops::Range<usize>>,
+    pub directive: DecodedDirective,
+}
+
+pub enum DecodedDirective {
+    Satisfy,
+    Maximize(core::ops::Range<usize>),
+    Minimize(core::ops::Range<usize>),
+}
+
+pub struct EncodedPredicate<'a> {
+    pub state_reads: Vec<&'a [u8]>,
+    pub constraints: Vec<&'a [u8]>,
+    pub directive: EncodedDirective<'a>,
+}
+
+pub enum EncodedDirective<'a> {
+    Satisfy,
+    Maximize(&'a [u8]),
+    Minimize(&'a [u8]),
+}
+
+pub struct PredicateBytes {
+    pub header: DecodedHeader,
+    pub bytes: Vec<u8>,
+}
+
+/// Tag for the [`Directive`]`.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u8)]
+pub enum DirectiveTag {
+    /// All constraints must be satisfied.
+    #[default]
+    Satisfy,
+    /// Maximize the objective value.
+    Maximize,
+    /// Minimize the objective value.
+    Minimize,
+}
+
+pub struct StaticHeader(pub [u8; Self::SIZE]);
+
+pub struct Len<T>(T);
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EncodedSize {
+    pub num_state_reads: usize,
+    pub num_constraints: usize,
+    pub state_read_lens_sum: usize,
+    pub constraint_lens_sum: usize,
+    pub directive_size: usize,
+}
+pub struct PredicateBounds<S, C> {
+    pub num_state_reads: usize,
+    pub num_constraints: usize,
+    pub state_read_lens: S,
+    pub constraint_lens: C,
+    pub directive_size: usize,
+}
+
+pub fn encoded_size(sizes: &EncodedSize) -> usize {
+    StaticHeader::SIZE
+        + sizes.num_state_reads * core::mem::size_of::<u16>()
+        + sizes.num_constraints * core::mem::size_of::<u16>()
+        + sizes.state_read_lens_sum
+        + sizes.constraint_lens_sum
+        + sizes.directive_size
+}
+
+/// Check the bounds of a predicate.
+///
+/// This ensures the predicate is within the limits set by the validation rules.
+pub fn check_predicate_bounds<S, C>(mut bounds: PredicateBounds<S, C>) -> Result<(), PredicateError>
+where
+    S: Iterator<Item = usize>,
+    C: Iterator<Item = usize>,
+{
+    if bounds.num_state_reads > Predicate::MAX_STATE_READS {
+        return Err(PredicateError::TooManyStateReads(bounds.num_state_reads));
+    }
+    if bounds.num_constraints > Predicate::MAX_CONSTRAINTS {
+        return Err(PredicateError::TooManyConstraints(bounds.num_constraints));
+    }
+    let mut state_read_lens_sum: usize = 0;
+    if let Some(err) = bounds.state_read_lens.find_map(|len| {
+        state_read_lens_sum = state_read_lens_sum.saturating_add(len);
+        (len > Predicate::MAX_STATE_READ_SIZE_BYTES)
+            .then_some(PredicateError::StateReadTooLarge(len))
+    }) {
+        return Err(err);
+    }
+
+    let mut constraint_lens_sum: usize = 0;
+    if let Some(err) = bounds.constraint_lens.find_map(|len| {
+        constraint_lens_sum = constraint_lens_sum.saturating_add(len);
+        (len > Predicate::MAX_CONSTRAINT_SIZE_BYTES)
+            .then_some(PredicateError::ConstraintTooLarge(len))
+    }) {
+        return Err(err);
+    }
+
+    let encoded_size = encoded_size(&EncodedSize {
+        num_state_reads: bounds.num_state_reads,
+        num_constraints: bounds.num_constraints,
+        state_read_lens_sum,
+        constraint_lens_sum,
+        directive_size: bounds.directive_size,
+    });
+
+    if encoded_size > Predicate::MAX_PREDICATE_BYTES {
+        return Err(PredicateError::PredicateTooLarge(encoded_size));
+    }
+    // Check the directive size.
+    if bounds.directive_size > Predicate::MAX_DIRECTIVE_SIZE_BYTES {
+        return Err(PredicateError::DirectiveTooLarge(bounds.directive_size));
+    }
+    Ok(())
+}
+
+impl TryFrom<&Predicate> for EncodedHeader {
+    type Error = PredicateError;
+
+    /// Creates the encoded header from a [`Predicate`].
+    fn try_from(predicate: &Predicate) -> Result<Self, Self::Error> {
+        let static_header = StaticHeader::try_from(predicate)?;
+        let lens = encode_program_lengths(predicate);
+        Ok(Self {
+            static_header,
+            lens,
+        })
+    }
+}
+
+impl TryFrom<&Predicate> for StaticHeader {
+    type Error = PredicateError;
+
+    fn try_from(predicate: &Predicate) -> Result<Self, Self::Error> {
+        Ok(StaticHeader::from(StaticHeaderLayout::try_from(predicate)?))
+    }
+}
+
+impl TryFrom<&Predicate> for StaticHeaderLayout {
+    type Error = PredicateError;
+
+    fn try_from(predicate: &Predicate) -> Result<Self, Self::Error> {
+        predicate.check_predicate_bounds()?;
+
+        // All following casts are safe because we have checked the bounds.
+        let directive_len = match &predicate.directive {
+            Directive::Satisfy => 0,
+            Directive::Maximize(program) | Directive::Minimize(program) => program.len() as u16,
+        };
+        Ok(Self {
+            num_state_reads: predicate.state_read.len() as u8,
+            num_constraints: predicate.constraints.len() as u8,
+            directive_tag: DirectiveTag::from(&predicate.directive),
+            directive_len,
+        })
+    }
+}
+
+impl DecodedHeader {
+    pub fn decode(buf: &[u8]) -> DecodeResult<Self> {
+        use StaticHeaderLayout as S;
+        S::check_len(buf.len())?;
+
+        let sh = S::decode(buf)?;
+
+        // Following casts are safe because we have checked the buffer length.
+
+        let num_state_reads = sh.num_state_reads as usize;
+        let num_constraints = sh.num_constraints as usize;
+
+        let mut header = DecodedHeader {
+            state_reads: Vec::with_capacity(num_state_reads),
+            constraints: Vec::with_capacity(num_constraints),
+            directive: DecodedDirective::Satisfy,
+        };
+
+        sh.check_full_buf_len(buf)?;
+
+        let mut last = sh.full_len();
+        let state_read_lens = sh.decode_state_read_lens(buf).map(|len| {
+            let range = last..last + len;
+            last += len;
+            range
+        });
+
+        header.state_reads.extend(state_read_lens);
+
+        let constraint_lens = sh.decode_constraint_lens(buf).map(|len| {
+            let range = last..last + len;
+            last += len;
+            range
+        });
+
+        header.constraints.extend(constraint_lens);
+
+        match sh.directive_tag {
+            DirectiveTag::Satisfy => header.directive = DecodedDirective::Satisfy,
+            DirectiveTag::Maximize => {
+                header.directive = DecodedDirective::Maximize(last..sh.directive_len as usize);
+            }
+            DirectiveTag::Minimize => {
+                header.directive = DecodedDirective::Minimize(last..sh.directive_len as usize);
+            }
+        }
+
+        let bounds = PredicateBounds {
+            num_state_reads,
+            num_constraints,
+            state_read_lens: header.state_reads.iter().map(ExactSizeIterator::len),
+            constraint_lens: header.constraints.iter().map(ExactSizeIterator::len),
+            directive_size: sh.directive_len as usize,
+        };
+        check_predicate_bounds(bounds)?;
+
+        Ok(header)
+    }
+
+    pub fn decode_state_read(&self, buf: &[u8]) -> Vec<Vec<u8>> {
+        self.state_reads
+            .iter()
+            .map(|range| buf[range.clone()].to_vec())
+            .collect()
+    }
+
+    pub fn decode_constraints(&self, buf: &[u8]) -> Vec<Vec<u8>> {
+        self.constraints
+            .iter()
+            .map(|range| buf[range.clone()].to_vec())
+            .collect()
+    }
+
+    pub fn decode_directive(&self, buf: &[u8]) -> Directive {
+        match &self.directive {
+            DecodedDirective::Satisfy => Directive::Satisfy,
+            DecodedDirective::Maximize(range) => Directive::Maximize(buf[range.clone()].to_vec()),
+            DecodedDirective::Minimize(range) => Directive::Minimize(buf[range.clone()].to_vec()),
+        }
+    }
+}
+
+/// The layout and encoding of the lengths part of the header.
+/// For each [`Predicate::state_read`]:
+/// [`crate::StateReadBytecode::len`] as [`u16`] as `[u8; 2]` via [u16::to_be_bytes].
+/// Then append to [`Vec<u8>`].
+///
+/// Then for each [`Predicate::constraints`]:
+/// [`crate::ConstraintBytecode::len`] as [`u16`] as `[u8; 2]` via [u16::to_be_bytes].
+/// Then append to [`Vec<u8>`].
+///
+/// The precise layout is:
+/// ```no_run
+/// let i = predicate.state_read.len() - 1;
+/// let j = predicate.constraints.len() - 1;
+/// [
+///     state_read_len[0]_be_byte_0,
+///     state_read_len[0]_be_byte_1,
+///     // ...
+///     state_read_len[i]_be_byte_0,
+///     state_read_len[i]_be_byte_1,
+///     constraint_len[0]_be_byte_0,
+///     constraint_len[0]_be_byte_1,
+///     // ...
+///     constraint_len[j]_be_byte_0,
+///     constraint_len[j]_be_byte_1,
+/// ]
+/// ```
+///
+/// At a high level we have:
+/// &[`Predicate`] -> Vec<u8>
+/// This maps the length of each [`Predicate::state_read`] to a byte vector.
+/// Then appends the length of each [`Predicate::constraints`] to the same byte vector.
+///
+/// The encoding follows:
+/// &[u8] -> usize -> u16 -> [u8; 2]
+///
+/// ## Warning
+/// It's the callers responsibility to ensure the lengths are within bounds
+/// before calling this function.
+/// Use [`check_predicate_bounds`] to ensure the lengths are within bounds.
+fn encode_program_lengths(predicate: &Predicate) -> Vec<u8> {
+    let state_read_lens = predicate
+        .state_read
+        .iter()
+        .map(Vec::as_slice)
+        .flat_map(encode_bytes_length);
+    let constraint_lens = predicate
+        .constraints
+        .iter()
+        .map(Vec::as_slice)
+        .flat_map(encode_bytes_length);
+
+    let lengths_size = predicate
+        .state_read
+        .len()
+        .saturating_add(predicate.constraints.len())
+        .saturating_mul(2);
+    let mut buf = Vec::with_capacity(lengths_size);
+    buf.extend(state_read_lens);
+    buf.extend(constraint_lens);
+    buf
+}
+
+/// Encode the length of a byte slice as a big-endian u16 bytes.
+///
+/// ## Warning
+/// It's the callers responsibility to ensure the lengths are within bounds
+/// before calling this function.
+/// Use [`check_predicate_bounds`] to ensure the lengths are within bounds.
+fn encode_bytes_length(bytes: &[u8]) -> [u8; 2] {
+    (bytes.len() as u16).to_be_bytes()
+}
+
+impl StaticHeader {
+    /// The size of the static part of the header in bytes.
+    pub const SIZE: usize = 5;
+
+    pub const fn new(header: StaticHeaderLayout) -> Self {
+        let [directive_len_0, directive_len_1] = header.directive_len.to_be_bytes();
+        let buf = [
+            header.num_state_reads,
+            header.num_constraints,
+            header.directive_tag as u8,
+            directive_len_0,
+            directive_len_1,
+        ];
+        Self(buf)
+    }
+}
+
+impl StaticHeaderLayout {
+    pub const fn num_state_reads_ix() -> core::ops::Range<usize> {
+        0..core::mem::size_of::<u8>()
+    }
+
+    pub const fn num_constraints_ix() -> core::ops::Range<usize> {
+        let end = Self::num_state_reads_ix().end + core::mem::size_of::<u8>();
+        Self::num_state_reads_ix().end..end
+    }
+
+    pub const fn directive_tag_ix() -> core::ops::Range<usize> {
+        let end = Self::num_constraints_ix().end + core::mem::size_of::<u8>();
+        Self::num_constraints_ix().end..end
+    }
+
+    pub const fn directive_len_ix() -> core::ops::Range<usize> {
+        let end = Self::directive_tag_ix().end + core::mem::size_of::<u16>();
+        Self::directive_tag_ix().end..end
+    }
+
+    /// Panics if the buffer is too small.
+    /// Lengths must be checked before calling this method.
+    /// Check with [`StaticHeaderLayout::check_buf_len`].
+    pub fn get_num_state_reads(buf: &[u8]) -> u8 {
+        buf[Self::num_state_reads_ix().start]
+    }
+
+    /// Panics if the buffer is too small.
+    /// Lengths must be checked before calling this method.
+    /// Check with [`StaticHeaderLayout::check_buf_len`].
+    pub fn get_num_constraints(buf: &[u8]) -> u8 {
+        buf[Self::num_constraints_ix().start]
+    }
+
+    /// Panics if the buffer is too small.
+    /// Lengths must be checked before calling this method.
+    /// Check with [`StaticHeaderLayout::check_buf_len`].
+    pub fn get_directive_tag(buf: &[u8]) -> DecodeResult<DirectiveTag> {
+        buf[Self::directive_tag_ix().start]
+            .try_into()
+            .map_err(|_| DecodeError::MissingDirectiveTag)
+    }
+
+    /// Panics if the buffer is too small.
+    /// Lengths must be checked before calling this method.
+    /// Check with [`StaticHeaderLayout::check_buf_len`].
+    pub fn get_directive_len(buf: &[u8]) -> u16 {
+        let l = &buf[Self::directive_len_ix()];
+        u16::from_be_bytes([l[0], l[1]])
+    }
+
+    pub fn get_state_read_lens<'a>(&self, buf: &'a [u8]) -> &'a [u8] {
+        &buf[Self::directive_len_ix().end..self.num_state_reads as usize]
+    }
+
+    pub fn get_constraint_lens<'a>(&self, buf: &'a [u8]) -> &'a [u8] {
+        let start = Self::directive_len_ix().end + self.num_state_reads as usize;
+        &buf[start..self.num_constraints as usize]
+    }
+
+    pub const fn check_len(len: usize) -> DecodeResult<()> {
+        if len < StaticHeader::SIZE {
+            return Err(DecodeError::BufferTooSmall);
+        }
+        Ok(())
+    }
+
+    pub fn decode(buf: &[u8]) -> DecodeResult<Self> {
+        let num_state_reads = Self::get_num_state_reads(buf);
+        let num_constraints = Self::get_num_constraints(buf);
+        let directive_tag = Self::get_directive_tag(buf)?;
+        let directive_len = Self::get_directive_len(buf);
+        Ok(Self {
+            num_state_reads,
+            num_constraints,
+            directive_tag,
+            directive_len,
+        })
+    }
+
+    pub fn decode_state_read_lens<'h, 'b: 'h>(
+        &'h self,
+        buf: &'b [u8],
+    ) -> impl Iterator<Item = usize> + 'h {
+        self.get_state_read_lens(buf)
+            .chunks_exact(2)
+            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]) as usize)
+    }
+
+    pub fn decode_constraint_lens<'h, 'b: 'h>(
+        &'h self,
+        buf: &'b [u8],
+    ) -> impl Iterator<Item = usize> + 'h {
+        self.get_constraint_lens(buf)
+            .chunks_exact(2)
+            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]) as usize)
+    }
+
+    pub fn full_len(&self) -> usize {
+        StaticHeader::SIZE
+            + self.num_state_reads as usize * core::mem::size_of::<u16>()
+            + self.num_constraints as usize * core::mem::size_of::<u16>()
+    }
+
+    /// Check the length is big enough to hold the full header.
+    /// This includes the static part and the dynamic lengths part.
+    pub fn check_full_len(&self, len: usize) -> DecodeResult<()> {
+        if len < self.full_len() {
+            return Err(DecodeError::BufferTooSmall);
+        }
+        Ok(())
+    }
+    /// Check the length of the buffer is big enough to hold the header.
+    pub fn check_full_buf_len(&self, buf: &[u8]) -> DecodeResult<()> {
+        self.check_full_len(buf.len())
+    }
+}
+
+impl From<StaticHeaderLayout> for StaticHeader {
+    fn from(header: StaticHeaderLayout) -> Self {
+        Self::new(header)
+    }
+}
+
+impl From<&Directive> for DirectiveTag {
+    fn from(d: &Directive) -> Self {
+        match d {
+            Directive::Satisfy => DirectiveTag::Satisfy,
+            Directive::Maximize(_) => DirectiveTag::Maximize,
+            Directive::Minimize(_) => DirectiveTag::Minimize,
+        }
+    }
+}
+
+impl TryFrom<u8> for DirectiveTag {
+    type Error = DecodeError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(DirectiveTag::Satisfy),
+            1 => Ok(DirectiveTag::Maximize),
+            2 => Ok(DirectiveTag::Minimize),
+            _ => Err(DecodeError::InvalidDirectiveTag),
+        }
+    }
+}
+
+impl IntoIterator for EncodedHeader {
+    type Item = u8;
+    type IntoIter = core::iter::Chain<
+        core::array::IntoIter<u8, { StaticHeader::SIZE }>,
+        std::vec::IntoIter<u8>,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.static_header.0.into_iter().chain(self.lens)
+    }
+}

--- a/crates/types/src/predicate/header.rs
+++ b/crates/types/src/predicate/header.rs
@@ -16,32 +16,46 @@
 //! | [`num_constraints`] | 1 byte | [`length`] of [`constraints`] |
 //! | [`directive_tag`] | 1 byte | [`Directive`] variant as [`DirectiveTag`] |
 //! | [`directive_len`] | 2 bytes | length of the [`Directive::Maximize`] or [`Directive::Minimize`] program or `0` |
-//! | [`Len`] of each [`StateReadBytecode`]| 2 bytes * [`num_state_reads`] | length of each [`state_read`] program |
-//! | [`Len`] of each [`ConstraintBytecode`]| 2 bytes * [`num_constraints`] | length of each [`constraints`] program |
-//! | each [`StateReadBytecode`] | [`length`] of each [`StateReadBytecode`] * [`num_state_reads`] | bytes of each [`state_read`] program |
-//! | each [`ConstraintBytecode`] | [`length`] of each [`ConstraintBytecode`] * [`num_constraints`] | bytes of each [`constraints`] program |
+//! | encoded state read lengths | 2 bytes * [`num_state_reads`] | length of each [`state_read`] program |
+//! | encoded constraint lengths | 2 bytes * [`num_constraints`] | length of each [`constraints`] program |
+//! | each [`StateReadBytecode`] | each [`StateReadBytecode::len`] * [`num_state_reads`] | bytes of each [`state_read`] program |
+//! | each [`ConstraintBytecode`] | each [`ConstraintBytecode::len`] * [`num_constraints`] | bytes of each [`constraints`] program |
+//!
+//! ## Encoding program lengths
+//! This is how the lengths of the programs are encoded to bytes.
+//!
+//! The length of each program is encoded as a big-endian [`u16`].
+//!
+//! For each [`state_read`]: \
+//! [`StateReadBytecode::len`] as [`u16`] as `[u8; 2]` via [u16::to_be_bytes]. \
+//! Then append to [`Vec<u8>`].
+//!
+//! Then for each [`constraints`]: \
+//! [`ConstraintBytecode::len`] as [`u16`] as `[u8; 2]` via [u16::to_be_bytes]. \
+//! Then append to [`Vec<u8>`].
 //!
 //! ## Hashing
 //! The hash of the predicate is as follows:
 //! 1. Hash the bytes of the static part of the header.
 //! 2. Hash the bytes of the lens part of the header.
-//! 3. Hash the bytes of each [`Predicate::programs`] in the predicate
+//! 3. Hash the bytes of each [`Predicate::as_programs`] in the predicate
 //! (in the order of the iterator).
 //!
-//! [`num_state_reads`]: StaticHeaderLayout::num_state_reads
-//! [`num_constraints`]: StaticHeaderLayout::num_constraints
-//! [`directive_tag`]: StaticHeaderLayout::directive_tag
-//! [`directive_len`]: StaticHeaderLayout::directive_len
+//! [`num_state_reads`]: FixedSizeHeader::num_state_reads
+//! [`num_constraints`]: FixedSizeHeader::num_constraints
+//! [`directive_tag`]: FixedSizeHeader::directive_tag
+//! [`directive_len`]: FixedSizeHeader::directive_len
 //!
 //! [`state_read`]: Predicate::state_read
 //! [`constraints`]: Predicate::constraints
 //! [`StateReadBytecode`]: super::StateReadBytecode
+//! [`StateReadBytecode::len`]: super::StateReadBytecode::len
 //! [`ConstraintBytecode`]: super::ConstraintBytecode
+//! [`ConstraintBytecode::len`]: super::ConstraintBytecode::len
 //!
 //! [`length`]: Vec::len
 
 use super::{Directive, Predicate};
-use core::num::TryFromIntError;
 use error::DecodeResult;
 
 pub use error::DecodeError;
@@ -54,15 +68,21 @@ mod tests;
 /// The encoded [`Predicate`] header.
 ///
 /// This encodes the structure of the [`Predicate`] when encoding to bytes.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EncodedHeader {
-    /// The static part of the header.
-    pub static_header: StaticHeader,
+    /// The fixed size part of the header.
+    pub fixed_size_header: EncodedFixedSizeHeader,
     /// The dynamic lengths part of the header.
     pub lens: Vec<u8>,
 }
 
-/// Layout of the static part of the header.
-pub struct StaticHeaderLayout {
+/// The fixed size part of the header encoded to bytes.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EncodedFixedSizeHeader(pub [u8; Self::SIZE]);
+
+/// Layout of the fixed size part of the header.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FixedSizeHeader {
     /// Number of state reads.
     /// This must fit in a `u8`.
     pub num_state_reads: u8,
@@ -79,70 +99,100 @@ pub struct StaticHeaderLayout {
     pub directive_len: u16,
 }
 
+/// The header of a [`Predicate`] decoded.
+/// This contains the indices of the [`Predicate`]'s data in a buffer.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DecodedHeader {
+    /// The indices of the state read programs in a buffer.
     pub state_reads: Vec<core::ops::Range<usize>>,
+    /// The indices of the constraint check programs in a buffer.
     pub constraints: Vec<core::ops::Range<usize>>,
+    /// The directive and its indices in a buffer.
     pub directive: DecodedDirective,
 }
 
+/// The directive of a [`Predicate`] decoded.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum DecodedDirective {
+    /// [`Directive::Satisfy`].
     Satisfy,
+    /// [`Directive::Maximize`] with the indices to the program in a buffer.
     Maximize(core::ops::Range<usize>),
+    /// [`Directive::Minimize`] with the indices to the program in a buffer.
     Minimize(core::ops::Range<usize>),
 }
 
-pub struct EncodedPredicate<'a> {
-    pub state_reads: Vec<&'a [u8]>,
-    pub constraints: Vec<&'a [u8]>,
-    pub directive: EncodedDirective<'a>,
-}
-
-pub enum EncodedDirective<'a> {
-    Satisfy,
-    Maximize(&'a [u8]),
-    Minimize(&'a [u8]),
-}
-
+/// Encoded [`Predicate`] bytes with the [`DecodedHeader`].
+/// This allows access to the programs without decoding
+/// to an actually [`Predicate`] struct.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PredicateBytes {
+    /// The decoded header that points into the bytes.
     pub header: DecodedHeader,
+    /// The bytes of the encoded [`Predicate`].
     pub bytes: Vec<u8>,
+}
+
+/// A reference to the encoded [`Predicate`] bytes with the [`DecodedHeader`].
+/// This allows access to the programs without decoding
+/// to an actually [`Predicate`] struct or cloning the bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PredicateBytesRef<'a> {
+    /// The decoded header that points into the bytes.
+    pub header: DecodedHeader,
+    /// The bytes of the encoded [`Predicate`].
+    pub bytes: &'a [u8],
 }
 
 /// Tag for the [`Directive`]`.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum DirectiveTag {
-    /// All constraints must be satisfied.
+    /// [`Directive::Satisfy`].
     #[default]
     Satisfy,
-    /// Maximize the objective value.
+    /// [`Directive::Maximize`].
     Maximize,
-    /// Minimize the objective value.
+    /// [`Directive::Minimize`].
     Minimize,
 }
 
-pub struct StaticHeader(pub [u8; Self::SIZE]);
-
-pub struct Len<T>(T);
-
+/// Inputs to compute the size in bytes of a [`Predicate`] encoded to bytes.
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EncodedSize {
+pub(super) struct EncodedSize {
+    /// The number of state read programs.
     pub num_state_reads: usize,
+    /// The number of constraint check programs.
     pub num_constraints: usize,
+    /// The sum of the lengths of every state read program.
     pub state_read_lens_sum: usize,
+    /// The sum of the lengths of every constraint check program.
     pub constraint_lens_sum: usize,
-    pub directive_size: usize,
-}
-pub struct PredicateBounds<S, C> {
-    pub num_state_reads: usize,
-    pub num_constraints: usize,
-    pub state_read_lens: S,
-    pub constraint_lens: C,
+    /// The size of the directive program.
     pub directive_size: usize,
 }
 
-pub fn encoded_size(sizes: &EncodedSize) -> usize {
-    StaticHeader::SIZE
+/// Bounds for a [`Predicate`] to check if it's within the limits.
+///
+/// Limits are set out as const values on the [`Predicate`] impl.
+/// For example [`Predicate::MAX_BYTES`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(super) struct PredicateBounds<S, C> {
+    /// The number of state read programs.
+    pub num_state_reads: usize,
+    /// The number of constraint check programs.
+    pub num_constraints: usize,
+    /// Iterator over the lengths of each state read program.
+    pub state_read_lens: S,
+    /// Iterator over the lengths of each constraint check program.
+    pub constraint_lens: C,
+    /// The size of the directive program.
+    pub directive_size: usize,
+}
+
+/// The size in bytes of an encoded [`Predicate`].
+pub(super) fn encoded_size(sizes: &EncodedSize) -> usize {
+    EncodedFixedSizeHeader::SIZE
         + sizes.num_state_reads * core::mem::size_of::<u16>()
         + sizes.num_constraints * core::mem::size_of::<u16>()
         + sizes.state_read_lens_sum
@@ -153,7 +203,12 @@ pub fn encoded_size(sizes: &EncodedSize) -> usize {
 /// Check the bounds of a predicate.
 ///
 /// This ensures the predicate is within the limits set by the validation rules.
-pub fn check_predicate_bounds<S, C>(mut bounds: PredicateBounds<S, C>) -> Result<(), PredicateError>
+///
+/// Limits are set out as const values on the [`Predicate`] impl.
+/// For example [`Predicate::MAX_BYTES`].
+pub(super) fn check_predicate_bounds<S, C>(
+    mut bounds: PredicateBounds<S, C>,
+) -> Result<(), PredicateError>
 where
     S: Iterator<Item = usize>,
     C: Iterator<Item = usize>,
@@ -190,7 +245,7 @@ where
         directive_size: bounds.directive_size,
     });
 
-    if encoded_size > Predicate::MAX_PREDICATE_BYTES {
+    if encoded_size > Predicate::MAX_BYTES {
         return Err(PredicateError::PredicateTooLarge(encoded_size));
     }
     // Check the directive size.
@@ -205,24 +260,26 @@ impl TryFrom<&Predicate> for EncodedHeader {
 
     /// Creates the encoded header from a [`Predicate`].
     fn try_from(predicate: &Predicate) -> Result<Self, Self::Error> {
-        let static_header = StaticHeader::try_from(predicate)?;
+        let static_header = EncodedFixedSizeHeader::try_from(predicate)?;
         let lens = encode_program_lengths(predicate);
         Ok(Self {
-            static_header,
+            fixed_size_header: static_header,
             lens,
         })
     }
 }
 
-impl TryFrom<&Predicate> for StaticHeader {
+impl TryFrom<&Predicate> for EncodedFixedSizeHeader {
     type Error = PredicateError;
 
     fn try_from(predicate: &Predicate) -> Result<Self, Self::Error> {
-        Ok(StaticHeader::from(StaticHeaderLayout::try_from(predicate)?))
+        Ok(EncodedFixedSizeHeader::from(FixedSizeHeader::try_from(
+            predicate,
+        )?))
     }
 }
 
-impl TryFrom<&Predicate> for StaticHeaderLayout {
+impl TryFrom<&Predicate> for FixedSizeHeader {
     type Error = PredicateError;
 
     fn try_from(predicate: &Predicate) -> Result<Self, Self::Error> {
@@ -242,128 +299,14 @@ impl TryFrom<&Predicate> for StaticHeaderLayout {
     }
 }
 
-impl DecodedHeader {
-    pub fn decode(buf: &[u8]) -> DecodeResult<Self> {
-        use StaticHeaderLayout as S;
-        S::check_len(buf.len())?;
-
-        let sh = S::decode(buf)?;
-
-        // Following casts are safe because we have checked the buffer length.
-
-        let num_state_reads = sh.num_state_reads as usize;
-        let num_constraints = sh.num_constraints as usize;
-
-        let mut header = DecodedHeader {
-            state_reads: Vec::with_capacity(num_state_reads),
-            constraints: Vec::with_capacity(num_constraints),
-            directive: DecodedDirective::Satisfy,
-        };
-
-        sh.check_full_buf_len(buf)?;
-
-        let mut last = sh.full_len();
-        let state_read_lens = sh.decode_state_read_lens(buf).map(|len| {
-            let range = last..last + len;
-            last += len;
-            range
-        });
-
-        header.state_reads.extend(state_read_lens);
-
-        let constraint_lens = sh.decode_constraint_lens(buf).map(|len| {
-            let range = last..last + len;
-            last += len;
-            range
-        });
-
-        header.constraints.extend(constraint_lens);
-
-        match sh.directive_tag {
-            DirectiveTag::Satisfy => header.directive = DecodedDirective::Satisfy,
-            DirectiveTag::Maximize => {
-                header.directive = DecodedDirective::Maximize(last..sh.directive_len as usize);
-            }
-            DirectiveTag::Minimize => {
-                header.directive = DecodedDirective::Minimize(last..sh.directive_len as usize);
-            }
-        }
-
-        let bounds = PredicateBounds {
-            num_state_reads,
-            num_constraints,
-            state_read_lens: header.state_reads.iter().map(ExactSizeIterator::len),
-            constraint_lens: header.constraints.iter().map(ExactSizeIterator::len),
-            directive_size: sh.directive_len as usize,
-        };
-        check_predicate_bounds(bounds)?;
-
-        Ok(header)
-    }
-
-    pub fn decode_state_read(&self, buf: &[u8]) -> Vec<Vec<u8>> {
-        self.state_reads
-            .iter()
-            .map(|range| buf[range.clone()].to_vec())
-            .collect()
-    }
-
-    pub fn decode_constraints(&self, buf: &[u8]) -> Vec<Vec<u8>> {
-        self.constraints
-            .iter()
-            .map(|range| buf[range.clone()].to_vec())
-            .collect()
-    }
-
-    pub fn decode_directive(&self, buf: &[u8]) -> Directive {
-        match &self.directive {
-            DecodedDirective::Satisfy => Directive::Satisfy,
-            DecodedDirective::Maximize(range) => Directive::Maximize(buf[range.clone()].to_vec()),
-            DecodedDirective::Minimize(range) => Directive::Minimize(buf[range.clone()].to_vec()),
-        }
-    }
-}
-
-/// The layout and encoding of the lengths part of the header.
-/// For each [`Predicate::state_read`]:
-/// [`crate::StateReadBytecode::len`] as [`u16`] as `[u8; 2]` via [u16::to_be_bytes].
-/// Then append to [`Vec<u8>`].
+/// TODO: FIX THESE DOCS
 ///
-/// Then for each [`Predicate::constraints`]:
-/// [`crate::ConstraintBytecode::len`] as [`u16`] as `[u8; 2]` via [u16::to_be_bytes].
-/// Then append to [`Vec<u8>`].
-///
-/// The precise layout is:
-/// ```no_run
-/// let i = predicate.state_read.len() - 1;
-/// let j = predicate.constraints.len() - 1;
-/// [
-///     state_read_len[0]_be_byte_0,
-///     state_read_len[0]_be_byte_1,
-///     // ...
-///     state_read_len[i]_be_byte_0,
-///     state_read_len[i]_be_byte_1,
-///     constraint_len[0]_be_byte_0,
-///     constraint_len[0]_be_byte_1,
-///     // ...
-///     constraint_len[j]_be_byte_0,
-///     constraint_len[j]_be_byte_1,
-/// ]
-/// ```
-///
-/// At a high level we have:
-/// &[`Predicate`] -> Vec<u8>
-/// This maps the length of each [`Predicate::state_read`] to a byte vector.
-/// Then appends the length of each [`Predicate::constraints`] to the same byte vector.
-///
-/// The encoding follows:
-/// &[u8] -> usize -> u16 -> [u8; 2]
 ///
 /// ## Warning
 /// It's the callers responsibility to ensure the lengths are within bounds
 /// before calling this function.
 /// Use [`check_predicate_bounds`] to ensure the lengths are within bounds.
-fn encode_program_lengths(predicate: &Predicate) -> Vec<u8> {
+pub(super) fn encode_program_lengths(predicate: &Predicate) -> Vec<u8> {
     let state_read_lens = predicate
         .state_read
         .iter()
@@ -396,11 +339,12 @@ fn encode_bytes_length(bytes: &[u8]) -> [u8; 2] {
     (bytes.len() as u16).to_be_bytes()
 }
 
-impl StaticHeader {
+impl EncodedFixedSizeHeader {
     /// The size of the static part of the header in bytes.
     pub const SIZE: usize = 5;
 
-    pub const fn new(header: StaticHeaderLayout) -> Self {
+    /// Create a new encoded fixed size header from a [`FixedSizeHeader`].
+    pub const fn new(header: FixedSizeHeader) -> Self {
         let [directive_len_0, directive_len_1] = header.directive_len.to_be_bytes();
         let buf = [
             header.num_state_reads,
@@ -413,73 +357,86 @@ impl StaticHeader {
     }
 }
 
-impl StaticHeaderLayout {
+impl FixedSizeHeader {
+    /// Get the [`Self::num_state_reads`] indices for within a buffer.
     pub const fn num_state_reads_ix() -> core::ops::Range<usize> {
         0..core::mem::size_of::<u8>()
     }
 
+    /// Get the [`Self::num_constraints`] indices for within a buffer.
     pub const fn num_constraints_ix() -> core::ops::Range<usize> {
         let end = Self::num_state_reads_ix().end + core::mem::size_of::<u8>();
         Self::num_state_reads_ix().end..end
     }
 
+    /// Get the [`Self::directive_tag`] indices for within a buffer.
     pub const fn directive_tag_ix() -> core::ops::Range<usize> {
         let end = Self::num_constraints_ix().end + core::mem::size_of::<u8>();
         Self::num_constraints_ix().end..end
     }
 
+    /// Get the [`Self::directive_len`] indices for within a buffer.
     pub const fn directive_len_ix() -> core::ops::Range<usize> {
         let end = Self::directive_tag_ix().end + core::mem::size_of::<u16>();
         Self::directive_tag_ix().end..end
     }
 
+    /// Get the [`Self::num_state_reads`] byte from a buffer.
+    ///
+    /// # Panics
     /// Panics if the buffer is too small.
     /// Lengths must be checked before calling this method.
-    /// Check with [`StaticHeaderLayout::check_buf_len`].
+    /// Check with [`FixedSizeHeader::check_len`].
     pub fn get_num_state_reads(buf: &[u8]) -> u8 {
         buf[Self::num_state_reads_ix().start]
     }
 
+    /// Get the [`Self::num_constraints`] byte from a buffer.
+    ///
+    /// # Panics
     /// Panics if the buffer is too small.
     /// Lengths must be checked before calling this method.
-    /// Check with [`StaticHeaderLayout::check_buf_len`].
+    /// Check with [`FixedSizeHeader::check_len`].
     pub fn get_num_constraints(buf: &[u8]) -> u8 {
         buf[Self::num_constraints_ix().start]
     }
 
+    /// Get the [`Self::directive_tag`] byte from a buffer.
+    ///
+    /// # Errors
+    /// Returns an error if the byte is not a valid [`DirectiveTag`].
+    ///
+    /// # Panics
     /// Panics if the buffer is too small.
     /// Lengths must be checked before calling this method.
-    /// Check with [`StaticHeaderLayout::check_buf_len`].
+    /// Check with [`FixedSizeHeader::check_len`].
     pub fn get_directive_tag(buf: &[u8]) -> DecodeResult<DirectiveTag> {
         buf[Self::directive_tag_ix().start]
             .try_into()
             .map_err(|_| DecodeError::MissingDirectiveTag)
     }
 
+    /// Get the [`Self::directive_len`] [`u16`] from a buffer.
+    /// Uses [`u16::from_be_bytes`] to convert the bytes to a [`u16`].
+    ///
+    /// # Panics
     /// Panics if the buffer is too small.
     /// Lengths must be checked before calling this method.
-    /// Check with [`StaticHeaderLayout::check_buf_len`].
+    /// Check with [`FixedSizeHeader::check_len`].
     pub fn get_directive_len(buf: &[u8]) -> u16 {
         let l = &buf[Self::directive_len_ix()];
         u16::from_be_bytes([l[0], l[1]])
     }
 
-    pub fn get_state_read_lens<'a>(&self, buf: &'a [u8]) -> &'a [u8] {
-        &buf[Self::directive_len_ix().end..self.num_state_reads as usize]
-    }
-
-    pub fn get_constraint_lens<'a>(&self, buf: &'a [u8]) -> &'a [u8] {
-        let start = Self::directive_len_ix().end + self.num_state_reads as usize;
-        &buf[start..self.num_constraints as usize]
-    }
-
-    pub const fn check_len(len: usize) -> DecodeResult<()> {
-        if len < StaticHeader::SIZE {
-            return Err(DecodeError::BufferTooSmall);
-        }
-        Ok(())
-    }
-
+    /// Decode a fixed size header from bytes.
+    ///
+    /// # Errors
+    /// Returns an error if the byte is not a valid [`DirectiveTag`].
+    ///
+    /// # Panics
+    /// Panics if the buffer is too small.
+    /// Lengths must be checked before calling this method.
+    /// Check with [`FixedSizeHeader::check_len`].
     pub fn decode(buf: &[u8]) -> DecodeResult<Self> {
         let num_state_reads = Self::get_num_state_reads(buf);
         let num_constraints = Self::get_num_constraints(buf);
@@ -493,46 +450,285 @@ impl StaticHeaderLayout {
         })
     }
 
+    /// Get the state read lengths bytes from a buffer.
+    ///
+    /// # Panics
+    /// Panics if the buffer is too small.
+    /// Lengths must be checked before calling this method.
+    /// Check with [`FixedSizeHeader::check_header_len_and_program_lens`].
+    pub fn get_state_read_lens_bytes<'a>(&self, buf: &'a [u8]) -> &'a [u8] {
+        let start = Self::directive_len_ix().end;
+        let end = start + (self.num_state_reads as usize).saturating_mul(2);
+        &buf[start..end]
+    }
+
+    /// Get the constraint lengths bytes from a buffer.
+    ///
+    /// # Panics
+    /// Panics if the buffer is too small.
+    /// Lengths must be checked before calling this method.
+    /// Check with [`FixedSizeHeader::check_header_len_and_program_lens`].
+    pub fn get_constraint_lens_bytes<'a>(&self, buf: &'a [u8]) -> &'a [u8] {
+        let start =
+            Self::directive_len_ix().end + (self.num_state_reads as usize).saturating_mul(2);
+        let end = start + (self.num_constraints as usize).saturating_mul(2);
+        &buf[start..end]
+    }
+
+    /// Decode the state read lengths from a buffer.
+    ///
+    /// # Panics
+    /// Panics if the buffer is too small.
+    /// Lengths must be checked before calling this method.
+    /// Check with [`FixedSizeHeader::check_header_len_and_program_lens`].
     pub fn decode_state_read_lens<'h, 'b: 'h>(
         &'h self,
         buf: &'b [u8],
     ) -> impl Iterator<Item = usize> + 'h {
-        self.get_state_read_lens(buf)
+        self.get_state_read_lens_bytes(buf)
             .chunks_exact(2)
             .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]) as usize)
     }
 
+    /// Decode the constraint lengths from a buffer.
+    ///
+    /// # Panics
+    /// Panics if the buffer is too small.
+    /// Lengths must be checked before calling this method.
+    /// Check with [`FixedSizeHeader::check_header_len_and_program_lens`].
     pub fn decode_constraint_lens<'h, 'b: 'h>(
         &'h self,
         buf: &'b [u8],
     ) -> impl Iterator<Item = usize> + 'h {
-        self.get_constraint_lens(buf)
+        self.get_constraint_lens_bytes(buf)
             .chunks_exact(2)
             .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]) as usize)
     }
 
-    pub fn full_len(&self) -> usize {
-        StaticHeader::SIZE
-            + self.num_state_reads as usize * core::mem::size_of::<u16>()
-            + self.num_constraints as usize * core::mem::size_of::<u16>()
-    }
-
-    /// Check the length is big enough to hold the full header.
-    /// This includes the static part and the dynamic lengths part.
-    pub fn check_full_len(&self, len: usize) -> DecodeResult<()> {
-        if len < self.full_len() {
+    /// Check the length is big enough to hold the static part of the header.
+    ///
+    /// # Errors
+    /// Returns an error if the buffer is too small.
+    pub const fn check_len(len: usize) -> DecodeResult<()> {
+        if len < EncodedFixedSizeHeader::SIZE {
             return Err(DecodeError::BufferTooSmall);
         }
         Ok(())
     }
-    /// Check the length of the buffer is big enough to hold the header.
-    pub fn check_full_buf_len(&self, buf: &[u8]) -> DecodeResult<()> {
-        self.check_full_len(buf.len())
+
+    /// Check the length is big enough to hold the full header.
+    /// This includes the static part and the dynamic lengths part.
+    ///
+    /// # Errors
+    /// Returns an error if the buffer is too small.
+    pub fn check_header_len_and_program_lens(&self, len: usize) -> DecodeResult<()> {
+        if len < self.header_len_and_program_lens() {
+            return Err(DecodeError::BufferTooSmall);
+        }
+        Ok(())
+    }
+
+    /// The length of bytes of the header and the lengths of the programs.
+    pub fn header_len_and_program_lens(&self) -> usize {
+        EncodedFixedSizeHeader::SIZE
+            + self.num_state_reads as usize * core::mem::size_of::<u16>()
+            + self.num_constraints as usize * core::mem::size_of::<u16>()
     }
 }
 
-impl From<StaticHeaderLayout> for StaticHeader {
-    fn from(header: StaticHeaderLayout) -> Self {
+impl DecodedHeader {
+    /// Decode a header from bytes.
+    ///
+    /// # Errors
+    /// Returns an error if the buffer is too small
+    /// or the header is inconsistent
+    /// or the directive tag is invalid
+    /// or the predicate bounds are beyond the limits.
+    pub fn decode(buf: &[u8]) -> DecodeResult<Self> {
+        use FixedSizeHeader as Fixed;
+        Fixed::check_len(buf.len())?;
+
+        let fh = Fixed::decode(buf)?;
+
+        // Following casts are safe because we have checked the buffer length.
+
+        let num_state_reads = fh.num_state_reads as usize;
+        let num_constraints = fh.num_constraints as usize;
+
+        let mut header = DecodedHeader {
+            state_reads: Vec::with_capacity(num_state_reads),
+            constraints: Vec::with_capacity(num_constraints),
+            directive: DecodedDirective::Satisfy,
+        };
+
+        fh.check_header_len_and_program_lens(buf.len())?;
+
+        let mut last = fh.header_len_and_program_lens();
+        let state_read_lens = fh.decode_state_read_lens(buf).map(|len| {
+            let range = last..last + len;
+            last += len;
+            range
+        });
+
+        header.state_reads.extend(state_read_lens);
+
+        let constraint_lens = fh.decode_constraint_lens(buf).map(|len| {
+            let range = last..last + len;
+            last += len;
+            range
+        });
+
+        header.constraints.extend(constraint_lens);
+
+        match fh.directive_tag {
+            DirectiveTag::Satisfy => header.directive = DecodedDirective::Satisfy,
+            DirectiveTag::Maximize => {
+                header.directive =
+                    DecodedDirective::Maximize(last..(last + fh.directive_len as usize));
+            }
+            DirectiveTag::Minimize => {
+                header.directive =
+                    DecodedDirective::Minimize(last..(last + fh.directive_len as usize));
+            }
+        }
+
+        header.check_consistency(&fh)?;
+
+        let bounds = PredicateBounds {
+            num_state_reads,
+            num_constraints,
+            state_read_lens: header.state_reads.iter().map(ExactSizeIterator::len),
+            constraint_lens: header.constraints.iter().map(ExactSizeIterator::len),
+            directive_size: fh.directive_len as usize,
+        };
+        check_predicate_bounds(bounds)?;
+
+        Ok(header)
+    }
+
+    /// The number of bytes this header points to.
+    ///
+    /// This includes the [`EncodedFixedSizeHeader::SIZE`]
+    /// and the lengths of the programs as well as the programs themselves.
+    pub fn bytes_len(&self) -> usize {
+        let sr = self
+            .state_reads
+            .iter()
+            .fold(0usize, |acc, p| acc.saturating_add(p.len()));
+        let c = self
+            .constraints
+            .iter()
+            .fold(0usize, |acc, p| acc.saturating_add(p.len()));
+        let d = self.directive.len();
+        let lens = self
+            .state_reads
+            .len()
+            .saturating_add(self.constraints.len())
+            .saturating_mul(2);
+        EncodedFixedSizeHeader::SIZE
+            .saturating_add(sr)
+            .saturating_add(c)
+            .saturating_add(d)
+            .saturating_add(lens)
+    }
+
+    /// Decode the state read programs from a buffer.
+    /// This simply re-nests the programs from the flat buffer.
+    /// The underlying data is not modified.
+    ///
+    /// # Panics
+    /// Panics if the buffer is too small.
+    /// Lengths must be checked before calling this method.
+    /// Check with [`Self::bytes_len`].
+    pub fn decode_state_read(&self, buf: &[u8]) -> Vec<Vec<u8>> {
+        self.state_reads
+            .iter()
+            .map(|range| buf[range.clone()].to_vec())
+            .collect()
+    }
+
+    /// Decode the constraint check programs from a buffer.
+    /// This simply re-nests the programs from the flat buffer.
+    /// The underlying data is not modified.
+    ///
+    /// # Panics
+    /// Panics if the buffer is too small.
+    /// Lengths must be checked before calling this method.
+    /// Check with [`Self::bytes_len`].
+    pub fn decode_constraints(&self, buf: &[u8]) -> Vec<Vec<u8>> {
+        self.constraints
+            .iter()
+            .map(|range| buf[range.clone()].to_vec())
+            .collect()
+    }
+
+    /// Decode the directive from a buffer.
+    ///
+    /// # Panics
+    /// Panics if the buffer is too small.
+    /// Lengths must be checked before calling this method.
+    /// Check with [`Self::bytes_len`].
+    pub fn decode_directive(&self, buf: &[u8]) -> Directive {
+        match &self.directive {
+            DecodedDirective::Satisfy => Directive::Satisfy,
+            DecodedDirective::Maximize(range) => Directive::Maximize(buf[range.clone()].to_vec()),
+            DecodedDirective::Minimize(range) => Directive::Minimize(buf[range.clone()].to_vec()),
+        }
+    }
+
+    /// Check the [`DecodedHeader`] is consistent with the [`FixedSizeHeader`].
+    pub fn check_consistency(&self, header: &FixedSizeHeader) -> DecodeResult<()> {
+        if self.state_reads.len() != header.num_state_reads as usize {
+            return Err(DecodeError::IncorrectBodyLength);
+        }
+        if self.constraints.len() != header.num_constraints as usize {
+            return Err(DecodeError::IncorrectBodyLength);
+        }
+        match &self.directive {
+            DecodedDirective::Satisfy => {
+                if header.directive_tag != DirectiveTag::Satisfy {
+                    return Err(DecodeError::InvalidDirectiveTag);
+                }
+            }
+            DecodedDirective::Maximize(range) => {
+                if header.directive_tag != DirectiveTag::Maximize {
+                    return Err(DecodeError::InvalidDirectiveTag);
+                }
+                if range.len() != header.directive_len as usize {
+                    return Err(DecodeError::IncorrectBodyLength);
+                }
+            }
+            DecodedDirective::Minimize(range) => {
+                if header.directive_tag != DirectiveTag::Minimize {
+                    return Err(DecodeError::InvalidDirectiveTag);
+                }
+                if range.len() != header.directive_len as usize {
+                    return Err(DecodeError::IncorrectBodyLength);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl DecodedDirective {
+    /// Get the length of the directive program.
+    pub fn len(&self) -> usize {
+        match self {
+            DecodedDirective::Satisfy => 0,
+            DecodedDirective::Maximize(range) | DecodedDirective::Minimize(range) => range.len(),
+        }
+    }
+
+    /// Check if the directive program is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl From<FixedSizeHeader> for EncodedFixedSizeHeader {
+    fn from(header: FixedSizeHeader) -> Self {
         Self::new(header)
     }
 }
@@ -563,11 +759,11 @@ impl TryFrom<u8> for DirectiveTag {
 impl IntoIterator for EncodedHeader {
     type Item = u8;
     type IntoIter = core::iter::Chain<
-        core::array::IntoIter<u8, { StaticHeader::SIZE }>,
+        core::array::IntoIter<u8, { EncodedFixedSizeHeader::SIZE }>,
         std::vec::IntoIter<u8>,
     >;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.static_header.0.into_iter().chain(self.lens)
+        self.fixed_size_header.0.into_iter().chain(self.lens)
     }
 }

--- a/crates/types/src/predicate/header/error.rs
+++ b/crates/types/src/predicate/header/error.rs
@@ -1,0 +1,122 @@
+use std::fmt::Display;
+
+pub type DecodeResult<T> = core::result::Result<T, DecodeError>;
+
+#[derive(Debug)]
+/// Error when encoding a predicate.
+pub enum PredicateError {
+    /// State read too large.
+    StateReadTooLarge(usize),
+    /// Constraint too large.
+    ConstraintTooLarge(usize),
+    /// Directive too large.
+    DirectiveTooLarge(usize),
+    /// Too many state reads.
+    TooManyStateReads(usize),
+    /// Too many constraints.
+    TooManyConstraints(usize),
+    /// Predicate too large.
+    PredicateTooLarge(usize),
+}
+
+#[derive(Debug)]
+/// Error when decoding a predicate.
+pub enum DecodeError {
+    /// Missing number of state reads when decoding predicate header.
+    MissingNumStateReads,
+    /// Missing number of constraints when decoding predicate header.
+    MissingNumConstraints,
+    /// Missing directive tag when decoding predicate header.
+    MissingDirectiveTag,
+    /// Missing directive length when decoding predicate header.
+    MissingDirectiveLen,
+    /// Missing nested length when decoding predicate header.
+    MissingNestedLen,
+    /// Invalid directive tag when decoding predicate header.
+    InvalidDirectiveTag,
+    /// Overflow when decoding predicate.
+    Overflow,
+    /// Incorrect body length when decoding predicate.
+    IncorrectBodyLength,
+    /// Buffer too small when decoding predicate header.
+    BufferTooSmall,
+    /// Error with decoded predicate.
+    PredicateError(PredicateError),
+}
+
+impl std::error::Error for PredicateError {}
+impl std::error::Error for DecodeError {}
+
+impl Display for DecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DecodeError::MissingNumStateReads => {
+                write!(
+                    f,
+                    "missing number of state reads when decoding predicate header"
+                )
+            }
+            DecodeError::MissingNumConstraints => {
+                write!(
+                    f,
+                    "missing number of constraints when decoding predicate header"
+                )
+            }
+            DecodeError::MissingDirectiveTag => {
+                write!(f, "missing directive tag when decoding predicate header")
+            }
+            DecodeError::MissingDirectiveLen => {
+                write!(f, "missing directive length when decoding predicate header")
+            }
+            DecodeError::MissingNestedLen => {
+                write!(f, "missing nested length when decoding predicate header")
+            }
+            DecodeError::InvalidDirectiveTag => {
+                write!(f, "invalid directive tag when decoding predicate header")
+            }
+            DecodeError::Overflow => {
+                write!(f, "overflow when decoding predicate")
+            }
+            DecodeError::IncorrectBodyLength => {
+                write!(f, "incorrect body length when decoding predicate")
+            }
+            DecodeError::BufferTooSmall => {
+                write!(f, "buffer too small when decoding predicate header")
+            }
+            DecodeError::PredicateError(e) => {
+                write!(f, "predicate error: {}", e)
+            }
+        }
+    }
+}
+
+impl Display for PredicateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PredicateError::StateReadTooLarge(s) => {
+                write!(f, "state read too large when encoding predicate")
+            }
+            PredicateError::ConstraintTooLarge(s) => {
+                write!(f, "constraint too large when encoding predicate")
+            }
+            PredicateError::DirectiveTooLarge(s) => {
+                write!(f, "directive too large when encoding predicate")
+            }
+            PredicateError::TooManyStateReads(s) => {
+                write!(f, "too many state reads when encoding predicate")
+            }
+            PredicateError::TooManyConstraints(s) => {
+                write!(f, "too many constraints when encoding predicate")
+            }
+            PredicateError::PredicateTooLarge(s) => {
+                write!(f, "predicate too large when encoding predicate")
+            }
+        }
+    }
+}
+
+impl From<PredicateError> for DecodeError {
+    fn from(e: PredicateError) -> Self {
+        DecodeError::PredicateError(e)
+    }
+}

--- a/crates/types/src/predicate/header/error.rs
+++ b/crates/types/src/predicate/header/error.rs
@@ -94,22 +94,22 @@ impl Display for PredicateError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             PredicateError::StateReadTooLarge(s) => {
-                write!(f, "state read too large when encoding predicate")
+                write!(f, "state read too large when encoding predicate: {}", s)
             }
             PredicateError::ConstraintTooLarge(s) => {
-                write!(f, "constraint too large when encoding predicate")
+                write!(f, "constraint too large when encoding predicate: {}", s)
             }
             PredicateError::DirectiveTooLarge(s) => {
-                write!(f, "directive too large when encoding predicate")
+                write!(f, "directive too large when encoding predicate: {}", s)
             }
             PredicateError::TooManyStateReads(s) => {
-                write!(f, "too many state reads when encoding predicate")
+                write!(f, "too many state reads when encoding predicate: {}", s)
             }
             PredicateError::TooManyConstraints(s) => {
-                write!(f, "too many constraints when encoding predicate")
+                write!(f, "too many constraints when encoding predicate: {}", s)
             }
             PredicateError::PredicateTooLarge(s) => {
-                write!(f, "predicate too large when encoding predicate")
+                write!(f, "predicate too large when encoding predicate: {}", s)
             }
         }
     }

--- a/crates/types/src/predicate/header/error.rs
+++ b/crates/types/src/predicate/header/error.rs
@@ -9,8 +9,6 @@ pub enum PredicateError {
     StateReadTooLarge(usize),
     /// Constraint too large.
     ConstraintTooLarge(usize),
-    /// Directive too large.
-    DirectiveTooLarge(usize),
     /// Too many state reads.
     TooManyStateReads(usize),
     /// Too many constraints.
@@ -26,14 +24,8 @@ pub enum DecodeError {
     MissingNumStateReads,
     /// Missing number of constraints when decoding predicate header.
     MissingNumConstraints,
-    /// Missing directive tag when decoding predicate header.
-    MissingDirectiveTag,
-    /// Missing directive length when decoding predicate header.
-    MissingDirectiveLen,
     /// Missing nested length when decoding predicate header.
     MissingNestedLen,
-    /// Invalid directive tag when decoding predicate header.
-    InvalidDirectiveTag,
     /// Overflow when decoding predicate.
     Overflow,
     /// Incorrect body length when decoding predicate.
@@ -62,17 +54,8 @@ impl Display for DecodeError {
                     "missing number of constraints when decoding predicate header"
                 )
             }
-            DecodeError::MissingDirectiveTag => {
-                write!(f, "missing directive tag when decoding predicate header")
-            }
-            DecodeError::MissingDirectiveLen => {
-                write!(f, "missing directive length when decoding predicate header")
-            }
             DecodeError::MissingNestedLen => {
                 write!(f, "missing nested length when decoding predicate header")
-            }
-            DecodeError::InvalidDirectiveTag => {
-                write!(f, "invalid directive tag when decoding predicate header")
             }
             DecodeError::Overflow => {
                 write!(f, "overflow when decoding predicate")
@@ -98,9 +81,6 @@ impl Display for PredicateError {
             }
             PredicateError::ConstraintTooLarge(s) => {
                 write!(f, "constraint too large when encoding predicate: {}", s)
-            }
-            PredicateError::DirectiveTooLarge(s) => {
-                write!(f, "directive too large when encoding predicate: {}", s)
             }
             PredicateError::TooManyStateReads(s) => {
                 write!(f, "too many state reads when encoding predicate: {}", s)

--- a/crates/types/src/predicate/header/tests.rs
+++ b/crates/types/src/predicate/header/tests.rs
@@ -1,0 +1,89 @@
+use crate::{contract::Contract, Word};
+
+use super::*;
+
+#[allow(dead_code)]
+const fn overhead(num_state_reads: usize, num_constraints: usize) -> usize {
+    StaticHeader::SIZE
+        + num_state_reads * core::mem::size_of::<u16>()
+        + num_constraints * core::mem::size_of::<u16>()
+}
+
+#[allow(clippy::assertions_on_constants)]
+const _CHECK_SIZES: () = {
+    const ALL_STATE_READS: usize =
+        overhead(Predicate::MAX_STATE_READS, 0) + Predicate::MAX_STATE_READS;
+    assert!(ALL_STATE_READS < Predicate::MAX_PREDICATE_BYTES);
+
+    const LARGE_STATE_READ: usize = overhead(1, 0) + Predicate::MAX_STATE_READ_SIZE_BYTES;
+    assert!(LARGE_STATE_READ < Predicate::MAX_PREDICATE_BYTES);
+
+    const ALL_CONSTRAINTS: usize =
+        overhead(Predicate::MAX_CONSTRAINTS, 0) + Predicate::MAX_CONSTRAINTS;
+    assert!(ALL_CONSTRAINTS < Predicate::MAX_PREDICATE_BYTES);
+
+    const LARGE_CONSTRAINT: usize = overhead(1, 0) + Predicate::MAX_CONSTRAINT_SIZE_BYTES;
+    assert!(LARGE_CONSTRAINT < Predicate::MAX_PREDICATE_BYTES);
+
+    assert!(Predicate::MAX_DIRECTIVE_SIZE_BYTES < Predicate::MAX_PREDICATE_BYTES);
+
+    // Ensure sizes fit in types.
+    assert!(Predicate::MAX_DIRECTIVE_SIZE_BYTES <= u16::MAX as usize);
+    assert!(Predicate::MAX_STATE_READ_SIZE_BYTES <= u16::MAX as usize);
+    assert!(Predicate::MAX_CONSTRAINT_SIZE_BYTES <= u16::MAX as usize);
+
+    assert!(Predicate::MAX_STATE_READS <= u8::MAX as usize);
+    assert!(Predicate::MAX_CONSTRAINTS <= u8::MAX as usize);
+};
+
+#[test]
+fn test_directive() {
+    let mut predicate = Predicate {
+        state_read: Default::default(),
+        constraints: Default::default(),
+        directive: Directive::Satisfy,
+    };
+
+    let r: StaticHeaderLayout = (&predicate).try_into().unwrap();
+    assert_eq!(r.directive_len, 0);
+
+    predicate.directive = Directive::Maximize(vec![0; 32]);
+    let r: StaticHeaderLayout = (&predicate).try_into().unwrap();
+    assert_eq!(r.directive_len, 32);
+
+    predicate.directive = Directive::Minimize(vec![0; 20]);
+    let r: StaticHeaderLayout = (&predicate).try_into().unwrap();
+    assert_eq!(r.directive_len, 20);
+}
+
+#[test]
+fn test_encoded_size() {
+    let mut size = EncodedSize {
+        num_state_reads: 10,
+        ..Default::default()
+    };
+
+    // Header + 10 lengths at 2 bytes each.
+    let mut expect = StaticHeader::SIZE + 10 * core::mem::size_of::<u16>();
+    assert_eq!(encoded_size(&size), expect);
+
+    // Add 20 constraint lens.
+    size.num_constraints = 20;
+    expect += 20 * core::mem::size_of::<u16>();
+    assert_eq!(encoded_size(&size), expect);
+
+    // Add 1500 bytes of state reads.
+    size.state_read_lens_sum = 1500;
+    expect += 1500;
+    assert_eq!(encoded_size(&size), expect);
+
+    // Add 2000 bytes of constraints.
+    size.constraint_lens_sum = 2000;
+    expect += 2000;
+    assert_eq!(encoded_size(&size), expect);
+
+    // Add 100 bytes of directive.
+    size.directive_size = 100;
+    expect += 100;
+    assert_eq!(encoded_size(&size), expect);
+}

--- a/crates/types/src/predicate/header/tests.rs
+++ b/crates/types/src/predicate/header/tests.rs
@@ -111,42 +111,42 @@ fn test_check_predicate_bounds() {
 }
 
 #[test]
-fn test_try_into_fixed_size_header() {
+fn test_fixed_size_header() {
     let mut predicate = Predicate {
         state_read: vec![vec![0; 10]; 10],
         constraints: vec![vec![0; 10]; 10],
     };
 
-    let header: FixedSizeHeader = (&predicate).try_into().unwrap();
+    let header: FixedSizeHeader = predicate.fixed_size_header().unwrap();
     assert_eq!(header.num_state_reads, 10);
     assert_eq!(header.num_constraints, 10);
 
     predicate.state_read = vec![vec![]; 256];
 
-    let header: Result<FixedSizeHeader, _> = (&predicate).try_into();
+    let header: Result<FixedSizeHeader, _> = predicate.fixed_size_header();
     assert!(header.is_err());
 }
 
 #[test]
-fn test_try_into_encoded_fixed_size_header() {
+fn test_encoded_fixed_size_header() {
     let predicate = Predicate {
         state_read: vec![],
         constraints: vec![vec![]; 255],
     };
 
-    let header: EncodedFixedSizeHeader = (&predicate).try_into().unwrap();
+    let header: EncodedFixedSizeHeader = predicate.fixed_size_header().unwrap().into();
     let expected = [0, 255];
     assert_eq!(header.0, expected);
 }
 
 #[test]
-fn test_try_into_encoded_header() {
+fn test_encoded_header() {
     let predicate = Predicate {
         state_read: (12..15).map(|i| vec![0; i]).collect(),
         constraints: (300..302).map(|i| vec![0; i]).collect(),
     };
 
-    let header: EncodedHeader = (&predicate).try_into().unwrap();
+    let header: EncodedHeader = predicate.encoded_header().unwrap();
     let expected = EncodedHeader {
         fixed_size_header: EncodedFixedSizeHeader([3, 2]),
         lens: vec![0, 12, 0, 13, 0, 14, 1, 44, 1, 45],
@@ -169,24 +169,6 @@ fn test_fixed_size_header_getters() {
 }
 
 #[test]
-fn test_program_lens() {
-    let buf = [2, 3, 0, 5, 1, 12, 1, 17, 2, 3, 0, 4, 9, 9];
-    let header = FixedSizeHeader::decode(&buf);
-    assert_eq!(header.get_state_read_lens_bytes(&buf), &[0, 5, 1, 12]);
-    assert_eq!(header.get_constraint_lens_bytes(&buf), &[1, 17, 2, 3, 0, 4]);
-
-    assert_eq!(
-        header.decode_state_read_lens(&buf).collect::<Vec<_>>(),
-        vec![5, 268]
-    );
-
-    assert_eq!(
-        header.decode_constraint_lens(&buf).collect::<Vec<_>>(),
-        vec![273, 515, 4]
-    );
-}
-
-#[test]
 fn test_decode_fixed_size_header() {
     let buf = [12, 99, 44, 44];
     let header = FixedSizeHeader::decode(&buf);
@@ -201,11 +183,7 @@ fn test_fixed_size_header_len() {
     FixedSizeHeader::check_len(2).unwrap();
     FixedSizeHeader::check_len(20).unwrap();
 
-    let len = FixedSizeHeader {
-        num_state_reads: 12,
-        num_constraints: 5,
-    }
-    .header_len_and_program_lens();
+    let len = state_len_buffer_offset(12, 5);
     assert_eq!(len, 36);
 
     let header = FixedSizeHeader {
@@ -231,8 +209,8 @@ fn test_decode_decoded_header() {
     assert_eq!(
         h,
         DecodedHeader {
-            state_reads: vec![],
-            constraints: vec![],
+            state_reads: &[],
+            constraints: &[],
         }
     );
 
@@ -241,29 +219,13 @@ fn test_decode_decoded_header() {
     assert_eq!(
         h,
         DecodedHeader {
-            state_reads: vec![12..13, 13..15],
-            constraints: vec![15..18, 18..22, 22..27],
+            state_reads: &[0, 1, 0, 2],
+            constraints: &[0, 3, 0, 4, 0, 5],
         }
     );
 
     let buf = [1, 0, 255, 255];
     DecodedHeader::decode(&buf).unwrap_err();
-}
-
-#[test]
-fn test_decode_state_reads() {
-    let buf = [2, 0, 0, 2, 0, 3, 55, 66, 77, 88, 99, 22];
-    let h = DecodedHeader::decode(&buf).unwrap();
-    let state_reads = h.decode_state_read(&buf);
-    assert_eq!(state_reads, vec![vec![55, 66], vec![77, 88, 99]]);
-}
-
-#[test]
-fn test_decode_constraints() {
-    let buf = [1, 2, 0, 2, 0, 2, 0, 3, 11, 22, 55, 66, 77, 88, 99, 22];
-    let h = DecodedHeader::decode(&buf).unwrap();
-    let constraints = h.decode_constraints(&buf);
-    assert_eq!(constraints, vec![vec![55, 66], vec![77, 88, 99]]);
 }
 
 #[test]
@@ -274,8 +236,8 @@ fn test_check_consistency() {
     };
 
     let original_dh = DecodedHeader {
-        state_reads: vec![5..6, 6..9],
-        constraints: vec![99..103, 88..901, 77..902],
+        state_reads: &[0, 1, 0, 3],
+        constraints: &[0, 4, 1, 250, 0, 42],
     };
     let fh = original_fh.clone();
     let dh = original_dh.clone();
@@ -290,11 +252,11 @@ fn test_check_consistency() {
     dh.check_consistency(&fh).unwrap_err();
 
     let mut dh = original_dh.clone();
-    dh.state_reads = vec![5..6, 6..9, 9..10];
+    dh.state_reads = &[1, 3, 1];
     dh.check_consistency(&original_fh).unwrap_err();
 
     let mut dh = original_dh.clone();
-    dh.constraints = vec![99..103, 88..901];
+    dh.constraints = &[4, 250];
     dh.check_consistency(&original_fh).unwrap_err();
 }
 
@@ -305,24 +267,34 @@ fn test_header_round_trips() {
         constraints: (255..259).map(|i| vec![0_u8; i]).collect(),
     };
 
-    let encoded = EncodedHeader::try_from(&predicate).unwrap();
+    let encoded = predicate.encoded_header().unwrap();
     let bytes: Vec<u8> = encoded.into_iter().collect();
     let decoded = DecodedHeader::decode(&bytes).unwrap();
 
-    assert_eq!(decoded.state_reads.len(), predicate.state_read.len());
-    assert_eq!(decoded.constraints.len(), predicate.constraints.len());
+    assert_eq!(decoded.num_state_reads(), predicate.state_read.len());
+    assert_eq!(decoded.num_constraints(), predicate.constraints.len());
 
     assert!(predicate
         .state_read
         .iter()
-        .zip(decoded.state_reads.iter())
-        .all(|(a, b)| a.len() == b.len()));
+        .zip(
+            decoded
+                .state_reads
+                .chunks_exact(mem::size_of::<u16>())
+                .map(decode_len),
+        )
+        .all(|(a, b)| a.len() == b));
 
     assert!(predicate
         .constraints
         .iter()
-        .zip(decoded.constraints.iter())
-        .all(|(a, b)| a.len() == b.len()));
+        .zip(
+            decoded
+                .constraints
+                .chunks_exact(mem::size_of::<u16>())
+                .map(decode_len),
+        )
+        .all(|(a, b)| a.len() == b));
 }
 
 #[test]
@@ -331,7 +303,7 @@ fn test_bytes_len() {
         state_read: (0..3).map(|i| vec![0_u8; i]).collect(),
         constraints: (255..259).map(|i| vec![0_u8; i]).collect(),
     };
-    let encoded = EncodedHeader::try_from(&predicate).unwrap();
+    let encoded = predicate.encoded_header().unwrap();
     let bytes: Vec<u8> = encoded.into_iter().collect();
     let decoded = DecodedHeader::decode(&bytes).unwrap();
 

--- a/crates/types/src/predicate/tests.rs
+++ b/crates/types/src/predicate/tests.rs
@@ -6,7 +6,7 @@ fn test_programs() {
         state_read: (0..3).map(|i| vec![0_u8; i]).collect(),
         constraints: (255..259).map(|i| vec![0_u8; i]).collect(),
     };
-    let programs = predicate.as_programs().collect::<Vec<_>>();
+    let programs = predicate.programs().collect::<Vec<_>>();
     assert_eq!(programs.len(), 7);
 
     for (i, program) in programs[0..3].iter().enumerate() {
@@ -75,7 +75,7 @@ fn test_decode() {
         1, 2, 2, // state reads
         200, 200, 201, 201, // constraints
     ];
-    let predicate = Predicate::decode(bytes).unwrap();
+    let predicate = Predicate::decode(&bytes).unwrap();
 
     let expected = Predicate {
         state_read: (0..3).map(|i| vec![i as u8; i]).collect(),
@@ -128,6 +128,6 @@ fn test_round_trips() {
         constraints: (200..202).map(|i| vec![i as u8; 2]).collect(),
     };
     let bytes: Vec<u8> = predicate.encode().unwrap().collect();
-    let decoded = Predicate::decode(bytes).unwrap();
+    let decoded = Predicate::decode(&bytes).unwrap();
     assert_eq!(predicate, decoded);
 }

--- a/crates/types/src/predicate/tests.rs
+++ b/crates/types/src/predicate/tests.rs
@@ -5,10 +5,9 @@ fn test_programs() {
     let predicate = Predicate {
         state_read: (0..3).map(|i| vec![0_u8; i]).collect(),
         constraints: (255..259).map(|i| vec![0_u8; i]).collect(),
-        directive: Directive::Minimize(vec![0_u8; 256]),
     };
     let programs = predicate.as_programs().collect::<Vec<_>>();
-    assert_eq!(programs.len(), 8);
+    assert_eq!(programs.len(), 7);
 
     for (i, program) in programs[0..3].iter().enumerate() {
         assert_eq!(&predicate.state_read[i], program);
@@ -17,8 +16,6 @@ fn test_programs() {
     for (i, program) in programs[3..7].iter().enumerate() {
         assert_eq!(&predicate.constraints[i], program);
     }
-
-    assert_eq!(&vec![0; 256], programs[7]);
 }
 
 #[test]
@@ -26,10 +23,9 @@ fn test_into_programs() {
     let predicate = Predicate {
         state_read: (0..3).map(|i| vec![0_u8; i]).collect(),
         constraints: (255..259).map(|i| vec![0_u8; i]).collect(),
-        directive: Directive::Minimize(vec![0_u8; 256]),
     };
     let programs = predicate.clone().into_programs().collect::<Vec<_>>();
-    assert_eq!(programs.len(), 8);
+    assert_eq!(programs.len(), 7);
 
     for (i, program) in programs[0..3].iter().enumerate() {
         assert_eq!(&predicate.state_read[i], program);
@@ -38,8 +34,6 @@ fn test_into_programs() {
     for (i, program) in programs[3..7].iter().enumerate() {
         assert_eq!(&predicate.constraints[i], program);
     }
-
-    assert_eq!(vec![0; 256], programs[7]);
 }
 
 #[test]
@@ -47,16 +41,14 @@ fn test_encode() {
     let predicate = Predicate {
         state_read: (0..3).map(|i| vec![i as u8; i]).collect(),
         constraints: (200..202).map(|i| vec![i as u8; 2]).collect(),
-        directive: Directive::Minimize(vec![33_u8; 2]),
     };
     let bytes: Vec<u8> = predicate.encode().unwrap().collect();
 
     let expected = vec![
-        3, 2, 2, 0, 2, // header
+        3, 2, // header
         0, 0, 0, 1, 0, 2, 0, 2, 0, 2, // lens
         1, 2, 2, // state reads
         200, 200, 201, 201, // constraints
-        33, 33, // directive
     ];
     assert_eq!(bytes, expected);
 }
@@ -66,32 +58,28 @@ fn test_encoded_size() {
     let predicate = Predicate {
         state_read: (0..3).map(|i| vec![i as u8; i]).collect(),
         constraints: (200..202).map(|i| vec![i as u8; 2]).collect(),
-        directive: Directive::Minimize(vec![33_u8; 2]),
     };
     let size = predicate.encoded_size();
-    let expected = 5 // header
+    let expected = 2 // header
         + 3 * 2 + 2 * 2 // lens
         + 3 // state reads
-        + 4 // constraints
-        + 2; // directive
+        + 4; // constraints
     assert_eq!(size, expected);
 }
 
 #[test]
 fn test_decode() {
     let bytes = vec![
-        3, 2, 2, 0, 2, // header
+        3, 2, // header
         0, 0, 0, 1, 0, 2, 0, 2, 0, 2, // lens
         1, 2, 2, // state reads
         200, 200, 201, 201, // constraints
-        33, 33, // directive
     ];
     let predicate = Predicate::decode(bytes).unwrap();
 
     let expected = Predicate {
         state_read: (0..3).map(|i| vec![i as u8; i]).collect(),
         constraints: (200..202).map(|i| vec![i as u8; 2]).collect(),
-        directive: Directive::Minimize(vec![33_u8; 2]),
     };
     assert_eq!(predicate, expected);
 }
@@ -101,7 +89,6 @@ fn check_predicate_bounds() {
     let mut predicate = Predicate {
         state_read: vec![],
         constraints: vec![],
-        directive: Directive::Satisfy,
     };
     predicate.check_predicate_bounds().unwrap();
 
@@ -117,10 +104,6 @@ fn check_predicate_bounds() {
     predicate.check_predicate_bounds().unwrap_err();
 
     predicate.constraints = vec![];
-    predicate.directive = Directive::Minimize(vec![0; Predicate::MAX_DIRECTIVE_SIZE_BYTES + 1]);
-    predicate.check_predicate_bounds().unwrap_err();
-
-    predicate.directive = Directive::Satisfy;
     predicate.state_read = vec![vec![0; Predicate::MAX_STATE_READ_SIZE_BYTES + 1]];
     predicate.check_predicate_bounds().unwrap_err();
 
@@ -135,7 +118,6 @@ fn check_predicate_bounds() {
 
     predicate.state_read = (0..Predicate::MAX_STATE_READS).map(|_| vec![]).collect();
     predicate.constraints = (0..Predicate::MAX_CONSTRAINTS).map(|_| vec![]).collect();
-    predicate.directive = Directive::Minimize(vec![0; Predicate::MAX_DIRECTIVE_SIZE_BYTES]);
     predicate.check_predicate_bounds().unwrap();
 }
 
@@ -144,7 +126,6 @@ fn test_round_trips() {
     let predicate = Predicate {
         state_read: (0..3).map(|i| vec![i as u8; i]).collect(),
         constraints: (200..202).map(|i| vec![i as u8; 2]).collect(),
-        directive: Directive::Minimize(vec![33_u8; 2]),
     };
     let bytes: Vec<u8> = predicate.encode().unwrap().collect();
     let decoded = Predicate::decode(bytes).unwrap();

--- a/crates/types/src/predicate/tests.rs
+++ b/crates/types/src/predicate/tests.rs
@@ -1,0 +1,152 @@
+use super::*;
+
+#[test]
+fn test_programs() {
+    let predicate = Predicate {
+        state_read: (0..3).map(|i| vec![0_u8; i]).collect(),
+        constraints: (255..259).map(|i| vec![0_u8; i]).collect(),
+        directive: Directive::Minimize(vec![0_u8; 256]),
+    };
+    let programs = predicate.as_programs().collect::<Vec<_>>();
+    assert_eq!(programs.len(), 8);
+
+    for (i, program) in programs[0..3].iter().enumerate() {
+        assert_eq!(&predicate.state_read[i], program);
+    }
+
+    for (i, program) in programs[3..7].iter().enumerate() {
+        assert_eq!(&predicate.constraints[i], program);
+    }
+
+    assert_eq!(&vec![0; 256], programs[7]);
+}
+
+#[test]
+fn test_into_programs() {
+    let predicate = Predicate {
+        state_read: (0..3).map(|i| vec![0_u8; i]).collect(),
+        constraints: (255..259).map(|i| vec![0_u8; i]).collect(),
+        directive: Directive::Minimize(vec![0_u8; 256]),
+    };
+    let programs = predicate.clone().into_programs().collect::<Vec<_>>();
+    assert_eq!(programs.len(), 8);
+
+    for (i, program) in programs[0..3].iter().enumerate() {
+        assert_eq!(&predicate.state_read[i], program);
+    }
+
+    for (i, program) in programs[3..7].iter().enumerate() {
+        assert_eq!(&predicate.constraints[i], program);
+    }
+
+    assert_eq!(vec![0; 256], programs[7]);
+}
+
+#[test]
+fn test_encode() {
+    let predicate = Predicate {
+        state_read: (0..3).map(|i| vec![i as u8; i]).collect(),
+        constraints: (200..202).map(|i| vec![i as u8; 2]).collect(),
+        directive: Directive::Minimize(vec![33_u8; 2]),
+    };
+    let bytes: Vec<u8> = predicate.encode().unwrap().collect();
+
+    let expected = vec![
+        3, 2, 2, 0, 2, // header
+        0, 0, 0, 1, 0, 2, 0, 2, 0, 2, // lens
+        1, 2, 2, // state reads
+        200, 200, 201, 201, // constraints
+        33, 33, // directive
+    ];
+    assert_eq!(bytes, expected);
+}
+
+#[test]
+fn test_encoded_size() {
+    let predicate = Predicate {
+        state_read: (0..3).map(|i| vec![i as u8; i]).collect(),
+        constraints: (200..202).map(|i| vec![i as u8; 2]).collect(),
+        directive: Directive::Minimize(vec![33_u8; 2]),
+    };
+    let size = predicate.encoded_size();
+    let expected = 5 // header
+        + 3 * 2 + 2 * 2 // lens
+        + 3 // state reads
+        + 4 // constraints
+        + 2; // directive
+    assert_eq!(size, expected);
+}
+
+#[test]
+fn test_decode() {
+    let bytes = vec![
+        3, 2, 2, 0, 2, // header
+        0, 0, 0, 1, 0, 2, 0, 2, 0, 2, // lens
+        1, 2, 2, // state reads
+        200, 200, 201, 201, // constraints
+        33, 33, // directive
+    ];
+    let predicate = Predicate::decode(bytes).unwrap();
+
+    let expected = Predicate {
+        state_read: (0..3).map(|i| vec![i as u8; i]).collect(),
+        constraints: (200..202).map(|i| vec![i as u8; 2]).collect(),
+        directive: Directive::Minimize(vec![33_u8; 2]),
+    };
+    assert_eq!(predicate, expected);
+}
+
+#[test]
+fn check_predicate_bounds() {
+    let mut predicate = Predicate {
+        state_read: vec![],
+        constraints: vec![],
+        directive: Directive::Satisfy,
+    };
+    predicate.check_predicate_bounds().unwrap();
+
+    predicate.state_read = (0..(Predicate::MAX_STATE_READS + 1))
+        .map(|_| vec![])
+        .collect();
+    predicate.check_predicate_bounds().unwrap_err();
+
+    predicate.state_read = vec![];
+    predicate.constraints = (0..(Predicate::MAX_CONSTRAINTS + 1))
+        .map(|_| vec![])
+        .collect();
+    predicate.check_predicate_bounds().unwrap_err();
+
+    predicate.constraints = vec![];
+    predicate.directive = Directive::Minimize(vec![0; Predicate::MAX_DIRECTIVE_SIZE_BYTES + 1]);
+    predicate.check_predicate_bounds().unwrap_err();
+
+    predicate.directive = Directive::Satisfy;
+    predicate.state_read = vec![vec![0; Predicate::MAX_STATE_READ_SIZE_BYTES + 1]];
+    predicate.check_predicate_bounds().unwrap_err();
+
+    predicate.state_read.pop();
+    predicate.check_predicate_bounds().unwrap();
+
+    predicate.constraints = vec![vec![0; Predicate::MAX_CONSTRAINT_SIZE_BYTES + 1]];
+    predicate.check_predicate_bounds().unwrap_err();
+
+    predicate.constraints.pop();
+    predicate.check_predicate_bounds().unwrap();
+
+    predicate.state_read = (0..Predicate::MAX_STATE_READS).map(|_| vec![]).collect();
+    predicate.constraints = (0..Predicate::MAX_CONSTRAINTS).map(|_| vec![]).collect();
+    predicate.directive = Directive::Minimize(vec![0; Predicate::MAX_DIRECTIVE_SIZE_BYTES]);
+    predicate.check_predicate_bounds().unwrap();
+}
+
+#[test]
+fn test_round_trips() {
+    let predicate = Predicate {
+        state_read: (0..3).map(|i| vec![i as u8; i]).collect(),
+        constraints: (200..202).map(|i| vec![i as u8; 2]).collect(),
+        directive: Directive::Minimize(vec![33_u8; 2]),
+    };
+    let bytes: Vec<u8> = predicate.encode().unwrap().collect();
+    let decoded = Predicate::decode(bytes).unwrap();
+    assert_eq!(predicate, decoded);
+}


### PR DESCRIPTION
This introduces a encoding and decoding scheme for predicates.
The best place to start would be the `types/src/predicate/header.rs` as it contains the main logic around how the encoding header is created and the bytes layout.
There are some more high level functions on the `Predicate` itself.
I would suggest generating the docs `cargo doc -p essential-types --open`.

Additionally:
- The hashing has been updated to use this encoding.
- The limits on sizes have been moved to the `Predicate` so that when encoding / decoding the sizes can be checked.
- The encoding is also documented thoroughly in the `header.rs` module.
- There is thorough test coverage