### PR TITLE
feat: sha256 byte granularity

### DIFF
--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -376,18 +376,17 @@ StateRead:
               description: |
                 Produce a SHA 256 hash from the specified data.
                 
-                Hashes are byte aligned. Use `extra_padding_len` to remove 
-                padding from the end of the data.
+                Hashes are byte aligned so length is number of bytes **not** number of words.
               panics:
-                - extra_padding_len is greater than 8.
-                - data_len is 0 and padding length is not 0.
-                - data_len is longer than the data.
-              stack_in: [data, data_len, extra_padding_len]
+                - data_len * 8 is longer than the data.
+              stack_in: [data, data_len]
               stack_out: [hash_w0, hash_w1, hash_w2, hash_w3]
 
             VerifyEd25519:
               opcode: 0x51
-              description: Validate an Ed25519 signature against a public key.
+              description: |
+                Validate an Ed25519 signature against a public key.
+                Data is byte aligned so length is number of bytes **not** number of words.
               stack_in:
                 [
                   data,

--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -386,6 +386,7 @@ StateRead:
               opcode: 0x51
               description: |
                 Validate an Ed25519 signature against a public key.
+
                 Data is byte aligned so length is number of bytes **not** number of words.
               stack_in:
                 [

--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -373,8 +373,16 @@ StateRead:
           group:
             Sha256:
               opcode: 0x50
-              description: Produce a SHA 256 hash from the specified data.
-              stack_in: [data, data_len]
+              description: |
+                Produce a SHA 256 hash from the specified data.
+                
+                Hashes are byte aligned. Use `extra_padding_len` to remove 
+                padding from the end of the data.
+              panics:
+                - extra_padding_len is greater than 8.
+                - data_len is 0 and padding length is not 0.
+                - data_len is longer than the data.
+              stack_in: [data, data_len, extra_padding_len]
               stack_out: [hash_w0, hash_w1, hash_w2, hash_w3]
 
             VerifyEd25519:

--- a/crates/check/tests/encoding.rs
+++ b/crates/check/tests/encoding.rs
@@ -25,6 +25,7 @@ async fn test_encoding_sig_and_pub_key() {
             constraint_vm::asm::Access::DecisionVar.into(),
             // Hash the key.
             constraint_vm::asm::Stack::Push(5).into(),
+            constraint_vm::asm::Stack::Push(0).into(),
             constraint_vm::asm::Crypto::Sha256.into(),
             // Get the secp256k1 signature. It is 9 slots.
             constraint_vm::asm::Stack::Push(1).into(),

--- a/crates/check/tests/encoding.rs
+++ b/crates/check/tests/encoding.rs
@@ -24,8 +24,7 @@ async fn test_encoding_sig_and_pub_key() {
             constraint_vm::asm::Stack::Push(5).into(),
             constraint_vm::asm::Access::DecisionVar.into(),
             // Hash the key.
-            constraint_vm::asm::Stack::Push(5).into(),
-            constraint_vm::asm::Stack::Push(0).into(),
+            constraint_vm::asm::Stack::Push(5 * 8).into(),
             constraint_vm::asm::Crypto::Sha256.into(),
             // Get the secp256k1 signature. It is 9 slots.
             constraint_vm::asm::Stack::Push(1).into(),

--- a/crates/constraint-vm/src/error.rs
+++ b/crates/constraint-vm/src/error.rs
@@ -218,9 +218,6 @@ pub enum CryptoError {
     /// Failed to parse SECP256k1 recovery id
     #[error("failed to parse secp256k1 recovery id")]
     Secp256k1RecoveryId,
-    /// Invalid Padding Size
-    #[error("invalid sha extra padding size: {0}")]
-    InvalidPaddingSize(Word),
 }
 
 /// Shorthand for a `Result` where the error type is a `StackError`.

--- a/crates/constraint-vm/src/error.rs
+++ b/crates/constraint-vm/src/error.rs
@@ -218,6 +218,9 @@ pub enum CryptoError {
     /// Failed to parse SECP256k1 recovery id
     #[error("failed to parse secp256k1 recovery id")]
     Secp256k1RecoveryId,
+    /// Invalid Padding Size
+    #[error("invalid sha extra padding size: {0}")]
+    InvalidPaddingSize(Word),
 }
 
 /// Shorthand for a `Result` where the error type is a `StackError`.

--- a/crates/types/src/convert.rs
+++ b/crates/types/src/convert.rs
@@ -16,8 +16,8 @@ pub fn word_from_bytes(bytes: [u8; 8]) -> Word {
 ///
 /// Ignores any bytes beyond the first 8.
 pub fn word_from_bytes_slice(bytes: &[u8]) -> Word {
-    let mut word = [0; 8];
-    let len = bytes.len().min(core::mem::size_of::<Word>());
+    let mut word = [0; core::mem::size_of::<Word>()];
+    let len = bytes.len().min(word.len());
     word[..len].copy_from_slice(&bytes[..len]);
     word_from_bytes(word)
 }

--- a/crates/types/src/convert.rs
+++ b/crates/types/src/convert.rs
@@ -12,6 +12,16 @@ pub fn word_from_bytes(bytes: [u8; 8]) -> Word {
     Word::from_be_bytes(bytes)
 }
 
+/// Convert a slice of bytes to a `Word`.
+///
+/// Ignores any bytes beyond the first 8.
+pub fn word_from_bytes_slice(bytes: &[u8]) -> Word {
+    let mut word = [0; 8];
+    let len = bytes.len().min(core::mem::size_of::<Word>());
+    word[..len].copy_from_slice(&bytes[..len]);
+    word_from_bytes(word)
+}
+
 /// A common conversion for 32-byte hashes and other addresses.
 #[rustfmt::skip]
 pub fn word_4_from_u8_32(bytes: [u8; 32]) -> [Word; 4] {


### PR DESCRIPTION
Adds an arg to `Sha256` that lets you specify the amount of padding to chop off the last word so that you can hash at byte granularity.