### PR TITLE
feat: PanicIf op

### DIFF
--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -427,6 +427,17 @@ StateRead:
                 - The jump is negative.
                 - The jump distance is zero.
               stack_in: [n_instruction, condition]
+            
+            PanicIf:
+              opcode: 0x64
+              description: |
+                Panic if the `condition` is true.
+
+                Returns the stack at the time of the panic
+                in the error message.
+              panics:
+                - The `condition` is true.
+              stack_in: [condition]
 
         Temporary:
           description: Operations for temporary memory.

--- a/crates/constraint-vm/src/error.rs
+++ b/crates/constraint-vm/src/error.rs
@@ -293,6 +293,12 @@ pub enum TotalControlFlowError {
     /// Attempted to halt if with an invalid condition
     #[error("halt if requires a boolean condition")]
     InvalidHaltIfCondition,
+    /// Attempted to panic if with an invalid condition
+    #[error("panic if requires a boolean condition")]
+    InvalidPanicIfCondition,
+    /// The `PanicIf` operation was called with a `true` argument
+    #[error("program panicked with `PanicIf` operation. The stack at the time of panic: {0:?}")]
+    Panic(Vec<Word>),
 }
 
 /// Shorthand for a `Result` where the error type is a `TemporaryError`.

--- a/crates/constraint-vm/src/lib.rs
+++ b/crates/constraint-vm/src/lib.rs
@@ -338,6 +338,7 @@ pub fn step_on_total_control_flow(
         asm::TotalControlFlow::JumpForwardIf => total_control_flow::jump_forward_if(stack, pc),
         asm::TotalControlFlow::HaltIf => total_control_flow::halt_if(stack),
         asm::TotalControlFlow::Halt => Ok(Some(ProgramControlFlow::Halt)),
+        asm::TotalControlFlow::PanicIf => total_control_flow::panic_if(stack).map(|_| None),
     }
 }
 

--- a/crates/constraint-vm/src/total_control_flow.rs
+++ b/crates/constraint-vm/src/total_control_flow.rs
@@ -41,3 +41,15 @@ pub fn halt_if(stack: &mut Stack) -> OpResult<Option<ProgramControlFlow>> {
         Ok(None)
     }
 }
+
+/// Implementation of the `PanicIf` operation.
+pub fn panic_if(stack: &mut Stack) -> OpResult<()> {
+    let cond = stack.pop()?;
+    let cond = bool_from_word(cond).ok_or(TotalControlFlowError::InvalidPanicIfCondition)?;
+    if cond {
+        let stack = stack.iter().copied().collect();
+        Err(TotalControlFlowError::Panic(stack).into())
+    } else {
+        Ok(())
+    }
+}

--- a/crates/constraint-vm/src/total_control_flow/tests.rs
+++ b/crates/constraint-vm/src/total_control_flow/tests.rs
@@ -1,4 +1,9 @@
-use crate::{asm, exec_ops, test_util::test_access};
+use crate::{
+    asm,
+    error::{OpError, TotalControlFlowError},
+    exec_ops,
+    test_util::test_access,
+};
 
 #[test]
 fn test_jump_if() {
@@ -60,4 +65,46 @@ fn test_halt_if() {
     ];
     let stack = exec_ops(ops, access).unwrap();
     assert_eq!(&stack[..], &[3]);
+}
+
+#[test]
+fn test_panic_if() {
+    let mut stack = crate::Stack::default();
+    stack.push(42).unwrap();
+    stack.push(43).unwrap();
+    stack.push(1).unwrap();
+
+    let err = super::panic_if(&mut stack).unwrap_err();
+    assert!(err.to_string().ends_with("[42, 43]"),);
+    assert!(
+        matches!(err, OpError::TotalControlFlow(TotalControlFlowError::Panic(s)) if s == vec![42, 43])
+    );
+
+    let mut stack = crate::Stack::default();
+    stack.push(1).unwrap();
+
+    let err = super::panic_if(&mut stack).unwrap_err();
+    assert!(err.to_string().ends_with("[]"),);
+    assert!(
+        matches!(err, OpError::TotalControlFlow(TotalControlFlowError::Panic(s)) if s.is_empty())
+    );
+
+    let mut stack = crate::Stack::default();
+    stack.push(42).unwrap();
+    stack.push(43).unwrap();
+    stack.push(0).unwrap();
+
+    super::panic_if(&mut stack).unwrap();
+    assert_eq!(stack.len(), 2);
+    assert_eq!(stack.pop().unwrap(), 43);
+    assert_eq!(stack.pop().unwrap(), 42);
+
+    let mut stack = crate::Stack::default();
+    stack.push(42).unwrap();
+    stack.push(43).unwrap();
+    let err = super::panic_if(&mut stack).unwrap_err();
+    assert!(matches!(
+        err,
+        OpError::TotalControlFlow(TotalControlFlowError::InvalidPanicIfCondition)
+    ));
 }


### PR DESCRIPTION
Adds a panic op that returns the stack at the time of panic in the error. Useful for debugging but also failing on a state read if something is incorrect (like nil when shouldn't be).