### PR TITLE
feat: shorthand consts for every op

### DIFF
--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -57,7 +57,7 @@ StateRead:
 
             Select:
               opcode: 0x07
-              short: SLT
+              short: SEL
               description: |
                 Conditionally keep one of the top two elements on the stack.
 
@@ -303,7 +303,7 @@ StateRead:
             
             MutKeys:
               opcode: 0x34
-              short: MKEY
+              short: MKEYS
               description: |
                 Push the keys of the proposed state mutations onto the stack.
 
@@ -314,7 +314,7 @@ StateRead:
             
             PubVarKeys:
               opcode: 0x35
-              short: PKEY
+              short: PKEYS
               description: |
                 Push the keys of the pub vars at `pathway_id` onto the stack.
                 Note the order is non-deterministic because this is a set.
@@ -405,7 +405,7 @@ StateRead:
 
             PubVarLen:
               opcode: 0x3C
-              short: PLEN
+              short: PVLEN
               description: |
                 Get the length of the value indexed by `pathway_ix`
                 and key `key_0, ...key_N`.
@@ -536,7 +536,7 @@ StateRead:
           group:
             Alloc:
               opcode: 0x70
-              short: TALC
+              short: ALOCT
               description: |
                 Allocate new memory to the end of the temporary memory.
                 Sets new memory to 0.
@@ -548,7 +548,7 @@ StateRead:
 
             Load:
               opcode: 0x71
-              short: TLD
+              short: LOD
               description: Load the value at the index of temporary memory onto the stack.
               panics:
                 - Index is out of bounds.
@@ -557,7 +557,7 @@ StateRead:
 
             Store:
               opcode: 0x72
-              short: TSTR
+              short: STO
               description: Store the value at the index of temporary memory.
               panics:
                 - Index is out of bounds.
@@ -568,13 +568,13 @@ StateRead:
       group:
         AllocSlots:
           opcode: 0x80
-          short: SALC
+          short: ALOCS
           description: Allocate new slots to the end of the memory.
           stack_in: [size]
 
         Load:
           opcode: 0x81
-          short: SLD
+          short: LODS
           description: |
             Load the value at the index of a slot onto the stack.
 
@@ -588,7 +588,7 @@ StateRead:
 
         Store:
           opcode: 0x82
-          short: SSTR
+          short: STOS
           description: Store the value at the index of state slots.
           panics:
             - Index is out of bounds.
@@ -596,7 +596,7 @@ StateRead:
 
         LoadWord:
           opcode: 0x83
-          short: SLDW
+          short: LODWS
           description: |
             Load the word at the index of the value at
             the slot onto the stack.
@@ -607,7 +607,7 @@ StateRead:
 
         StoreWord:
           opcode: 0x84
-          short: SSTRW
+          short: STORWS
           description: |
             Store the word at the index of the value
             at the slot.
@@ -617,7 +617,7 @@ StateRead:
 
         Clear:
           opcode: 0x85
-          short: SCLR
+          short: CLR
           description: Clear the value at the index.
           panics:
             - Index is out of bounds.
@@ -625,7 +625,7 @@ StateRead:
 
         ClearRange:
           opcode: 0x86
-          short: SCLRR
+          short: CLRR
           description: Clear a range of values.
           panics:
             - The range is out of bounds.

--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -29,6 +29,7 @@ StateRead:
 
             DupFrom:
               opcode: 0x04
+              short: DUPF
               description: |
                 Duplicate the word at the given stack depth index.
 
@@ -44,6 +45,7 @@ StateRead:
 
             SwapIndex:
               opcode: 0x06
+              short: SWAPI
               description: |
                 Swap the top word on the stack with the word at the given stack depth index.
 
@@ -55,6 +57,7 @@ StateRead:
 
             Select:
               opcode: 0x07
+              short: SLT
               description: |
                 Conditionally keep one of the top two elements on the stack.
 
@@ -64,6 +67,7 @@ StateRead:
 
             SelectRange:
               opcode: 0x08
+              short: SLTR
               description: |
                 Conditionally keep one of the top two ranges on the stack.
 
@@ -77,6 +81,7 @@ StateRead:
 
             Repeat:
               opcode: 0x09
+              short: REP
               description: |
                 Repeat a section of code the number of times.
                 Takes a boolean to either count from 0 up or from the number of repeats down to 0.
@@ -84,6 +89,7 @@ StateRead:
 
             RepeatEnd:
               opcode: 0x0A
+              short: REPE
               description: |
                 Increment or decrements the top counter on the repeat stack.
                 If the counter is counting up and `counter == limit - 1`
@@ -107,6 +113,7 @@ StateRead:
 
             EqRange:
               opcode: 0x11
+              short: EQRA
               description: |
                 Check equality of two ranges on the stack.
 
@@ -160,6 +167,7 @@ StateRead:
 
             EqSet:
               opcode: 0x19
+              short: EQST
               description: |
                 Pop two sets off the stack and check if they are equal.
                 This is set equality so order does not matter.
@@ -174,12 +182,14 @@ StateRead:
             
             BitAnd:
               opcode: 0x1A
+              short: BAND
               description: Bitwise AND of two words.
               stack_in: [lhs, rhs]
               stack_out: ["lhs & rhs"]
             
             BitOr:
               opcode: 0x1B
+              short: BOR
               description: Bitwise OR of two words.
               stack_in: [lhs, rhs]
               stack_out: ["lhs | rhs"]
@@ -249,6 +259,7 @@ StateRead:
           group:
             ThisAddress:
               opcode: 0x30
+              short: THIS
               description: |
                 Get the content hash of this predicate.
 
@@ -257,6 +268,7 @@ StateRead:
 
             ThisContractAddress:
               opcode: 0x31
+              short: THISC
               description: |
                 Get the content hash of the contract this predicate belongs to.
 
@@ -265,6 +277,7 @@ StateRead:
 
             ThisPathway:
               opcode: 0x32
+              short: PATH
               description: |
                 Get the pathway of this predicate.
 
@@ -273,6 +286,7 @@ StateRead:
             
             PredicateAt:
               opcode: 0x33
+              short: PRED
               description: Get the predicate at solution data pathway.
               stack_in: [pathway]
               stack_out:
@@ -289,6 +303,7 @@ StateRead:
             
             MutKeys:
               opcode: 0x34
+              short: MKEY
               description: |
                 Push the keys of the proposed state mutations onto the stack.
 
@@ -299,6 +314,7 @@ StateRead:
             
             PubVarKeys:
               opcode: 0x35
+              short: PKEY
               description: |
                 Push the keys of the pub vars at `pathway_id` onto the stack.
                 Note the order is non-deterministic because this is a set.
@@ -308,11 +324,13 @@ StateRead:
 
             RepeatCounter:
               opcode: 0x36
+              short: REPC
               description: Access the top repeat counters current value.
               stack_out: [counter_value]
 
             DecisionVar:
               opcode: 0x37
+              short: VAR
               description: |
                 Access a range of `len` words starting from `value_ix` within the decision variable located at `slot_ix`.
 
@@ -327,6 +345,7 @@ StateRead:
 
             DecisionVarLen:
               opcode: 0x38
+              short: VLEN
               description: Get the length of a the decision variable value located at `slot_ix`.
               panics:
                 - slot_ix is out of range.
@@ -353,6 +372,7 @@ StateRead:
 
             StateLen:
               opcode: 0x3A
+              short: SLEN
               description: |
                 Get the length of a state value at a specified `slot_ix`.
 
@@ -368,6 +388,7 @@ StateRead:
 
             PubVar:
               opcode: 0x3B
+              short: PVAR
               description: |
                 Access a range of public decision variable words at `pathway_ix` 
                 and key `key_0, ...key_N`.
@@ -384,6 +405,7 @@ StateRead:
 
             PubVarLen:
               opcode: 0x3C
+              short: PLEN
               description: |
                 Get the length of the value indexed by `pathway_ix`
                 and key `key_0, ...key_N`.
@@ -392,6 +414,7 @@ StateRead:
 
             NumSlots:
               opcode: 0x3D
+              short: NSLT
               description: |
                 Get the number of decision var or state slots.
 
@@ -412,6 +435,7 @@ StateRead:
           group:
             Sha256:
               opcode: 0x50
+              short: SHA2
               description: |
                 Produce a SHA 256 hash from the specified data.
                 
@@ -423,6 +447,7 @@ StateRead:
 
             VerifyEd25519:
               opcode: 0x51
+              short: VRFYED
               description: |
                 Validate an Ed25519 signature against a public key.
 
@@ -448,6 +473,7 @@ StateRead:
 
             RecoverSecp256k1:
               opcode: 0x52
+              short: RSECP
               description: |
                 Recover the public key from a secp256k1 signature.
 
@@ -475,15 +501,18 @@ StateRead:
           group:
             Halt:
               opcode: 0x60
+              short: HLT
               description: End the execution of the program.
 
             HaltIf:
               opcode: 0x61
+              short: HLTIF
               description: Halt the program if the value is true.
               stack_in: [value]
 
             JumpForwardIf:
               opcode: 0x63
+              short: JMPIF
               description: Jump forward the given number of instructions if the value is true.
               panics:
                 - The jump is negative.
@@ -492,6 +521,7 @@ StateRead:
             
             PanicIf:
               opcode: 0x64
+              short: PNCIF
               description: |
                 Panic if the `condition` is true.
 
@@ -506,6 +536,7 @@ StateRead:
           group:
             Alloc:
               opcode: 0x70
+              short: TALC
               description: |
                 Allocate new memory to the end of the temporary memory.
                 Sets new memory to 0.
@@ -517,6 +548,7 @@ StateRead:
 
             Load:
               opcode: 0x71
+              short: TLD
               description: Load the value at the index of temporary memory onto the stack.
               panics:
                 - Index is out of bounds.
@@ -525,6 +557,7 @@ StateRead:
 
             Store:
               opcode: 0x72
+              short: TSTR
               description: Store the value at the index of temporary memory.
               panics:
                 - Index is out of bounds.
@@ -535,11 +568,13 @@ StateRead:
       group:
         AllocSlots:
           opcode: 0x80
+          short: SALC
           description: Allocate new slots to the end of the memory.
           stack_in: [size]
 
         Load:
           opcode: 0x81
+          short: SLD
           description: |
             Load the value at the index of a slot onto the stack.
 
@@ -553,6 +588,7 @@ StateRead:
 
         Store:
           opcode: 0x82
+          short: SSTR
           description: Store the value at the index of state slots.
           panics:
             - Index is out of bounds.
@@ -560,6 +596,7 @@ StateRead:
 
         LoadWord:
           opcode: 0x83
+          short: SLDW
           description: |
             Load the word at the index of the value at
             the slot onto the stack.
@@ -570,6 +607,7 @@ StateRead:
 
         StoreWord:
           opcode: 0x84
+          short: SSTRW
           description: |
             Store the word at the index of the value
             at the slot.
@@ -579,6 +617,7 @@ StateRead:
 
         Clear:
           opcode: 0x85
+          short: SCLR
           description: Clear the value at the index.
           panics:
             - Index is out of bounds.
@@ -586,6 +625,7 @@ StateRead:
 
         ClearRange:
           opcode: 0x86
+          short: SCLRR
           description: Clear a range of values.
           panics:
             - The range is out of bounds.
@@ -593,17 +633,20 @@ StateRead:
 
         Length:
           opcode: 0x87
+          short: SMLEN
           description: Get the current length of the memory.
           stack_out: [length]
 
         ValueLen:
           opcode: 0x88
+          short: SVLEN
           description: Get the current length of a given value at the index.
           stack_in: [index]
           stack_out: [length]
 
     KeyRange:
       opcode: 0x90
+      short: KRNG
       description: |
         Read a range of values at each key from state starting at the key
         into state slots starting at the slot index.
@@ -616,6 +659,7 @@ StateRead:
 
     KeyRangeExtern:
       opcode: 0x91
+      short: KREX
       description: |
         Read a range of values at each key from external state starting at the key
         into state slots starting at the slot index.

--- a/crates/asm-spec/src/lib.rs
+++ b/crates/asm-spec/src/lib.rs
@@ -41,6 +41,8 @@ pub struct Op {
     pub opcode: u8,
     pub description: String,
     #[serde(default)]
+    pub short: String,
+    #[serde(default)]
     pub panics: Vec<String>,
     #[serde(default)]
     pub num_arg_bytes: u8,

--- a/crates/check/tests/util.rs
+++ b/crates/check/tests/util.rs
@@ -151,41 +151,50 @@ pub fn random_keypair(seed: [u8; 32]) -> (SecretKey, PublicKey) {
 pub fn test_predicate_42(entropy: Word) -> Predicate {
     Predicate {
         // State read program to read state slot 0.
-        state_read: vec![state_read_vm::asm::to_bytes([
-            state_read_vm::asm::Stack::Push(1).into(),
-            state_read_vm::asm::StateSlots::AllocSlots.into(),
-            state_read_vm::asm::Stack::Push(0).into(),
-            state_read_vm::asm::Stack::Push(0).into(),
-            state_read_vm::asm::Stack::Push(0).into(),
-            state_read_vm::asm::Stack::Push(0).into(),
-            state_read_vm::asm::Stack::Push(4).into(),
-            state_read_vm::asm::Stack::Push(1).into(),
-            state_read_vm::asm::Stack::Push(0).into(),
-            state_read_vm::asm::StateRead::KeyRange,
-            state_read_vm::asm::TotalControlFlow::Halt.into(),
-        ])
-        .collect()],
+        state_read: test_predicate_42_state_read(),
         // Program to check pre-mutation value is None and
         // post-mutation value is 42 at slot 0.
-        constraints: vec![constraint_vm::asm::to_bytes([
-            state_read_vm::asm::Stack::Push(entropy).into(),
-            state_read_vm::asm::Stack::Pop.into(),
-            constraint_vm::asm::Stack::Push(0).into(), // slot
-            constraint_vm::asm::Stack::Push(0).into(), // pre
-            constraint_vm::asm::Access::StateLen.into(),
-            constraint_vm::asm::Stack::Push(0).into(),
-            constraint_vm::asm::Pred::Eq.into(),
-            constraint_vm::asm::Stack::Push(0).into(), // slot_ix
-            constraint_vm::asm::Stack::Push(0).into(), // value_ix
-            constraint_vm::asm::Stack::Push(1).into(), // len
-            constraint_vm::asm::Stack::Push(1).into(), // post
-            constraint_vm::asm::Access::State.into(),
-            constraint_vm::asm::Stack::Push(42).into(),
-            constraint_vm::asm::Pred::Eq.into(),
-            constraint_vm::asm::Pred::And.into(),
-        ])
-        .collect()],
+        constraints: test_predicate_42_constraint(entropy),
     }
+}
+
+fn test_predicate_42_state_read() -> Vec<Vec<u8>> {
+    use state_read_vm::asm::short::*;
+    vec![state_read_vm::asm::to_bytes([
+        PUSH(1),
+        SALC,
+        PUSH(0),
+        PUSH(0),
+        PUSH(0),
+        PUSH(0),
+        PUSH(4),
+        PUSH(1),
+        PUSH(0),
+        KRNG,
+    ])
+    .collect()]
+}
+
+fn test_predicate_42_constraint(entropy: Word) -> Vec<Vec<u8>> {
+    use constraint_vm::asm::short::*;
+    vec![constraint_vm::asm::to_bytes([
+        PUSH(entropy),
+        POP,
+        PUSH(0), // slot_ix
+        PUSH(0), // pre
+        SLEN,
+        PUSH(0),
+        EQ,
+        PUSH(0), // slot_ix
+        PUSH(0), // value_ix
+        PUSH(1), // len
+        PUSH(1), // post
+        STATE,
+        PUSH(42),
+        EQ,
+        AND,
+    ])
+    .collect()]
 }
 
 pub fn contract_addr(predicates: &contract::SignedContract) -> ContentAddress {

--- a/crates/check/tests/util.rs
+++ b/crates/check/tests/util.rs
@@ -162,7 +162,7 @@ fn test_predicate_42_state_read() -> Vec<Vec<u8>> {
     use state_read_vm::asm::short::*;
     vec![state_read_vm::asm::to_bytes([
         PUSH(1),
-        SALC,
+        ALOCS,
         PUSH(0),
         PUSH(0),
         PUSH(0),

--- a/crates/constraint-asm/src/lib.rs
+++ b/crates/constraint-asm/src/lib.rs
@@ -51,6 +51,12 @@ mod op {
     pub mod bytes_iter {
         essential_asm_gen::gen_constraint_op_bytes_iter!();
     }
+
+    /// Short hand names for the operations.
+    pub mod short {
+        use super::{Constraint as Op, *};
+        essential_asm_gen::gen_constraint_op_consts!();
+    }
 }
 
 /// Typed representation of the opcode, without any associated data.

--- a/crates/state-asm/src/lib.rs
+++ b/crates/state-asm/src/lib.rs
@@ -26,6 +26,12 @@ mod op {
         pub use essential_constraint_asm::bytes_iter::*;
         essential_asm_gen::gen_state_read_op_bytes_iter!();
     }
+
+    /// Short hand names for the operations.
+    pub mod short {
+        use super::{StateRead as Op, *};
+        essential_asm_gen::gen_state_op_consts!();
+    }
 }
 
 /// Typed representation of the opcode, without any associated data.


### PR DESCRIPTION
Generates shorthand consts to make writing ASM easier.
For constraints do:
```rust
use essential_constraint_asm::short::*;
```
For state reads do:
```rust
use essential_constraint_asm::short::*;
```
I would recommend generating the docs:
```bash
cargo doc --open -p essential-state-asm
```
```bash
cargo doc --open -p essential-constraint-asm
```
and checking out the `short` module.

I also updated the `test_predicate_42` in `check::tests::utils` as an example.