### PR TITLE
feat: add predicate exists op

### DIFF
--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -428,6 +428,17 @@ StateRead:
               stack_in: [which_slots]
               stack_out: [len]
 
+            PredicateExists:
+              opcode: 0x3E
+              short: PEX
+              description: |
+                Check if a solution to a predicate exists within the same solution
+                with the hash of the arguments and address.
+
+                Returns `true` if the predicate exists.
+              stack_in: [sha256(arg0len, arg0, argNlen, argN, contract_addr, predicate_addr)]
+              stack_out: [bool]
+
         # Byte 4 reserved for Access ops
 
         Crypto:

--- a/crates/constraint-vm/src/access/predicate_exists.rs
+++ b/crates/constraint-vm/src/access/predicate_exists.rs
@@ -1,0 +1,151 @@
+use essential_types::{ContentAddress, PredicateAddress};
+
+use super::*;
+
+#[test]
+fn test_predicate_exists() {
+    // Sanity
+    let (mut stack, data, cache) = setup(
+        &[Setup {
+            contract_addr: [0; 32],
+            predicate_addr: [0; 32],
+            args: vec![vec![1, 2, 3, 4]],
+        }],
+        0,
+    );
+    assert!(check(&mut stack, &data, &cache).unwrap());
+
+    // Multiple
+    let (mut stack, data, cache) = setup(
+        &[
+            Setup {
+                contract_addr: [0; 32],
+                predicate_addr: [0; 32],
+                args: vec![vec![1, 2, 3, 4]],
+            },
+            Setup {
+                contract_addr: [1; 32],
+                predicate_addr: [1; 32],
+                args: vec![vec![1, 3, 4], vec![5]],
+            },
+            Setup {
+                contract_addr: [5; 32],
+                predicate_addr: [6; 32],
+                args: vec![vec![]],
+            },
+        ],
+        1,
+    );
+    assert!(check(&mut stack, &data, &cache).unwrap());
+
+    // Duplicate
+    let (mut stack, data, cache) = setup(
+        &[
+            Setup {
+                contract_addr: [0; 32],
+                predicate_addr: [0; 32],
+                args: vec![vec![1, 2, 3, 4]],
+            },
+            Setup {
+                contract_addr: [0; 32],
+                predicate_addr: [0; 32],
+                args: vec![vec![1, 2, 3, 4]],
+            },
+            Setup {
+                contract_addr: [5; 32],
+                predicate_addr: [6; 32],
+                args: vec![vec![]],
+            },
+        ],
+        1,
+    );
+    assert!(check(&mut stack, &data, &cache).unwrap());
+
+    // Not exists
+    let (mut stack, mut data, cache) = setup(
+        &[
+            Setup {
+                contract_addr: [0; 32],
+                predicate_addr: [0; 32],
+                args: vec![vec![1, 2, 3, 4]],
+            },
+            Setup {
+                contract_addr: [5; 32],
+                predicate_addr: [6; 32],
+                args: vec![vec![]],
+            },
+        ],
+        1,
+    );
+    data[1].predicate_to_solve = PredicateAddress {
+        contract: ContentAddress([0; 32]),
+        predicate: ContentAddress([0; 32]),
+    };
+    assert!(!check(&mut stack, &data, &cache).unwrap());
+
+    // Not exists
+    let (mut stack, data, cache) = setup(
+        &[
+            Setup {
+                contract_addr: [0; 32],
+                predicate_addr: [0; 32],
+                args: vec![vec![1, 2, 3, 4]],
+            },
+            Setup {
+                contract_addr: [5; 32],
+                predicate_addr: [6; 32],
+                args: vec![vec![]],
+            },
+        ],
+        1,
+    );
+    stack.pop().unwrap();
+    check(&mut stack, &data, &cache).unwrap_err();
+}
+
+fn check(stack: &mut Stack, data: &[SolutionData], cache: &LazyCache) -> OpResult<bool> {
+    predicate_exists(stack, data, cache)?;
+    let s = stack.iter().cloned().collect::<Vec<_>>();
+    assert_eq!(s.len(), 1);
+    let s: bool = s[0] == 1;
+    Ok(s)
+}
+
+struct Setup {
+    contract_addr: [u8; 32],
+    predicate_addr: [u8; 32],
+    args: Vec<Vec<Word>>,
+}
+
+fn setup(input: &[Setup], i: usize) -> (Stack, Vec<SolutionData>, LazyCache) {
+    let mut stack = Stack::default();
+    let cache = LazyCache::default();
+    let data: Vec<_> = input
+        .iter()
+        .map(|s| SolutionData {
+            predicate_to_solve: PredicateAddress {
+                contract: ContentAddress(s.contract_addr),
+                predicate: ContentAddress(s.predicate_addr),
+            },
+            decision_variables: s.args.clone(),
+            transient_data: Default::default(),
+            state_mutations: Default::default(),
+        })
+        .collect();
+    let words: Vec<_> = data
+        .iter()
+        .map(|d| {
+            let words = d.decision_variables.iter().flat_map(|slot| {
+                Some(slot.len() as Word)
+                    .into_iter()
+                    .chain(slot.iter().cloned())
+            });
+            let words = words.chain(word_4_from_u8_32(d.predicate_to_solve.contract.0));
+            let words = words.chain(word_4_from_u8_32(d.predicate_to_solve.predicate.0));
+            let bytes: Vec<_> = words.flat_map(bytes_from_word).collect();
+            word_4_from_u8_32(sha256(&bytes))
+        })
+        .collect();
+    stack.extend(words[i]).unwrap();
+    (stack, data, cache)
+}

--- a/crates/constraint-vm/src/cached.rs
+++ b/crates/constraint-vm/src/cached.rs
@@ -1,0 +1,27 @@
+use std::{collections::HashSet, sync::OnceLock};
+
+use essential_types::{solution::SolutionData, Hash};
+
+use crate::access::init_predicate_exists;
+
+#[derive(Default, Debug, PartialEq)]
+/// Lazily cache expensive to compute values.
+pub struct LazyCache {
+    /// Decision variables and addresses set of hashes.
+    pub dec_var_hashes: OnceLock<HashSet<Hash>>,
+}
+
+impl LazyCache {
+    /// Create a new empty `LazyCache`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get the decision variable hashes.
+    ///
+    /// The first time this is called, it will compute the hashes.
+    pub fn get_dec_var_hashes(&self, data: &[SolutionData]) -> &HashSet<Hash> {
+        self.dec_var_hashes
+            .get_or_init(|| init_predicate_exists(data).collect())
+    }
+}

--- a/crates/constraint-vm/src/cached.rs
+++ b/crates/constraint-vm/src/cached.rs
@@ -8,6 +8,7 @@ use crate::access::init_predicate_exists;
 /// Lazily cache expensive to compute values.
 pub struct LazyCache {
     /// Decision variables and addresses set of hashes.
+    /// See [`PredicateExists`][essential_constraint_asm::Op] for more details.
     pub dec_var_hashes: OnceLock<HashSet<Hash>>,
 }
 

--- a/crates/state-read-vm/src/lib.rs
+++ b/crates/state-read-vm/src/lib.rs
@@ -32,6 +32,7 @@ use constraint::{ProgramControlFlow, Repeat};
 #[doc(inline)]
 pub use error::{OpAsyncResult, OpResult, OpSyncResult, StateMemoryResult, StateReadResult};
 use error::{OpError, OpSyncError, StateMemoryError, StateReadError};
+use essential_constraint_vm::LazyCache;
 #[doc(inline)]
 pub use essential_constraint_vm::{
     self as constraint, Access, OpAccess, SolutionAccess, Stack, StateSlotSlice, StateSlots,
@@ -62,6 +63,8 @@ pub struct Vm {
     pub temp_memory: essential_constraint_vm::Memory,
     /// The repeat stack.
     pub repeat: Repeat,
+    /// Lazily cached data for the VM.
+    pub cache: LazyCache,
     /// The state memory that will be written to by this program.
     pub state_memory: StateMemory,
 }
@@ -286,9 +289,10 @@ pub(crate) fn step_op_sync(op: OpSync, access: Access, vm: &mut Vm) -> OpSyncRes
                 repeat,
                 pc,
                 temp_memory,
+                cache,
                 ..
             } = vm;
-            match constraint::step_op(access, op, stack, temp_memory, *pc, repeat)? {
+            match constraint::step_op(access, op, stack, temp_memory, *pc, repeat, cache)? {
                 Some(ProgramControlFlow::Pc(pc)) => return Ok(Some(pc)),
                 Some(ProgramControlFlow::Halt) => return Ok(None),
                 None => (),


### PR DESCRIPTION
Note that the dec vars have to be encoded with lengths before hashing them to distinguish between `[[0], [1, 2]]` and `[[0, 1], [2]]`.
I also added a `LazyCache` for the hashing so that if this op is not used the cost isn't paid but if it is it's only computed once.