### PR TITLE
refactor: Remove custom `Program` and `Programs` encoding

### DIFF
--- a/crates/types/src/predicate.rs
+++ b/crates/types/src/predicate.rs
@@ -64,10 +64,6 @@ pub struct Program(
     pub Vec<u8>,
 );
 
-/// A set of programs.
-#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct Programs(pub Vec<Program>);
-
 impl Predicate {
     /// Maximum number of nodes in a predicate.
     pub const MAX_NODES: u16 = 1000;
@@ -111,11 +107,6 @@ impl Predicate {
         let edges = self.edges.get(e_start..e_end)?;
         Some(edges)
     }
-}
-
-impl Programs {
-    /// Maximum number of programs in a set of programs.
-    pub const MAX_PROGRAMS: u16 = 1000;
 }
 
 impl Program {

--- a/crates/types/src/predicate/encode/tests.rs
+++ b/crates/types/src/predicate/encode/tests.rs
@@ -76,30 +76,3 @@ fn test_encode_predicate() {
     let decoded = decode_predicate(&encoded).unwrap();
     assert_eq!(decoded, predicate);
 }
-
-#[test]
-fn test_encode_programs() {
-    let program = Program(vec![1, 2, 3, 3]);
-    let expected = [4u16.to_be_bytes().to_vec(), program.clone().0].concat();
-    let encoded: Vec<u8> = encode_program(&program).unwrap().collect();
-    assert_eq!(encoded, expected);
-    let decoded = decode_program(&encoded).unwrap();
-    assert_eq!(decoded, program);
-    let programs = (1..10)
-        .map(|i| Program(vec![i; i as usize]))
-        .collect::<Vec<_>>();
-    let programs = Programs(programs);
-    let encoded: Vec<u8> = encode_programs(&programs.0).unwrap().collect();
-    let expected = [
-        9u16.to_be_bytes().to_vec(),
-        programs
-            .0
-            .iter()
-            .flat_map(|p| encode_program(p).unwrap())
-            .collect(),
-    ]
-    .concat();
-    assert_eq!(encoded, expected);
-    let decoded = decode_programs(&encoded).unwrap();
-    assert_eq!(decoded, programs);
-}


### PR DESCRIPTION
Under the new program DAG model proposed in #212, `Program`s will now be deployed independently from `Predicate`s.

After doing up a brief design for `Program` deployment (see [this issue](https://github.com/essential-contributions/essential-node/issues/148) downstream), it seems that we shouldn't need any special encoding for `Program`, nor any awareness of `Programs` sets at all.

A `Program`'s encoding is now its bytecode slice.

Muiltiple `Program`s can be deployed at once under multiple unique `Mutation`s within a single `Solution`.