### PR TITLE
feat: Improve `Solution` `Address` implementation

### DIFF
--- a/crates/hash/src/address_impl.rs
+++ b/crates/hash/src/address_impl.rs
@@ -1,9 +1,12 @@
+use crate::Address;
 use essential_types::{
-    contract::Contract, predicate::Predicate, solution::Solution, Block, ContentAddress,
+    contract::Contract,
+    convert::bytes_from_word,
+    predicate::Predicate,
+    solution::{Solution, SolutionData},
+    Block, ContentAddress, Word,
 };
 use sha2::Digest;
-
-use crate::{hash, Address};
 
 impl Address for Block {
     fn content_address(&self) -> ContentAddress {
@@ -17,7 +20,7 @@ impl Address for Predicate {
             // Invalid predicates can't be hashed.
             return ContentAddress([0; 32]);
         };
-        let mut hasher = <sha2::Sha256 as sha2::Digest>::new();
+        let mut hasher = <sha2::Sha256 as Digest>::new();
         hasher.update(header.fixed_size_header.0);
         hasher.update(header.lens);
         for item in self.programs() {
@@ -33,8 +36,43 @@ impl Address for Contract {
     }
 }
 
+/// Hash the [`SolutionData`] in a manner that treats `state_mutations` like a set.
+///
+/// Hashing occurs as follows:
+///
+/// - predicate_to_solve.contract.0
+impl Address for SolutionData {
+    fn content_address(&self) -> ContentAddress {
+        let mut hasher = <sha2::Sha256 as Digest>::new();
+
+        // Include the predicate address.
+        hasher.update(self.predicate_to_solve.contract.0);
+        hasher.update(self.predicate_to_solve.predicate.0);
+
+        // Decision variables must be in a particular order, required by the predicate
+        // that is being solved. Thus, we hash them in their existing order.
+        hasher.update(bytes_from_word(self.decision_variables.len() as Word));
+        for value in &self.decision_variables {
+            crate::hash_len_then_words(value, &mut hasher);
+        }
+
+        // State mutations are a set. In order to ensure the same CA is produced regardless
+        // of the ordering of the state mutations, we hash the mutations in order of `Key`.
+        hasher.update(bytes_from_word(self.state_mutations.len() as Word));
+        let mut ixs: Vec<_> = (0..self.state_mutations.len()).collect();
+        ixs.sort_by_key(|&ix| &self.state_mutations[ix].key);
+        ixs.iter().for_each(|&ix| {
+            let pair = &self.state_mutations[ix];
+            crate::hash_len_then_words(&pair.key, &mut hasher);
+            crate::hash_len_then_words(&pair.value, &mut hasher);
+        });
+
+        ContentAddress(hasher.finalize().into())
+    }
+}
+
 impl Address for Solution {
     fn content_address(&self) -> ContentAddress {
-        ContentAddress(hash(self))
+        crate::solution_addr::from_solution(self)
     }
 }

--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -74,16 +74,3 @@ pub fn hash_bytes_iter<'i>(iter: impl IntoIterator<Item = &'i [u8]>) -> Hash {
     }
     hasher.finalize().into()
 }
-
-/// Hash the length of the slice, then hash the words of the slice itself.
-fn hash_len_then_words(words: &[Word], hasher: &mut impl sha2::Digest) {
-    let len = words.len() as Word;
-    hasher.update(bytes_from_word(len));
-    words
-        .iter()
-        .copied()
-        .map(bytes_from_word)
-        .for_each(|bytes| {
-            hasher.update(bytes);
-        });
-}

--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -11,6 +11,7 @@ use sha2::Digest;
 mod address_impl;
 pub mod block_addr;
 pub mod contract_addr;
+pub mod solution_addr;
 
 /// Standardized trait for creating content addresses for
 /// types using the correct constructors.
@@ -72,4 +73,17 @@ pub fn hash_bytes_iter<'i>(iter: impl IntoIterator<Item = &'i [u8]>) -> Hash {
         hasher.update(bytes);
     }
     hasher.finalize().into()
+}
+
+/// Hash the length of the slice, then hash the words of the slice itself.
+fn hash_len_then_words(words: &[Word], hasher: &mut impl sha2::Digest) {
+    let len = words.len() as Word;
+    hasher.update(bytes_from_word(len));
+    words
+        .iter()
+        .copied()
+        .map(bytes_from_word)
+        .for_each(|bytes| {
+            hasher.update(bytes);
+        });
 }

--- a/crates/hash/src/solution_addr.rs
+++ b/crates/hash/src/solution_addr.rs
@@ -1,0 +1,40 @@
+//! A small collection of helper functions to assist in the calculation of an
+//! solution's content address.
+
+use essential_types::{solution::Solution, ContentAddress};
+
+/// Shorthand for the common case of producing a solution address from an
+/// iterator yielding references to [`SolutionData`]s.
+///
+/// If you have already calculated the content address for each `SolutionData` consider
+/// using [`from_data_addrs`] or [`from_data_addrs_slice`].
+pub fn from_solution(solution: &Solution) -> ContentAddress {
+    let data_addrs = solution.data.iter().map(crate::content_addr);
+    from_data_addrs(data_addrs)
+}
+
+/// Given the content address for each `SolutionData` in the `Solution`, produce the
+/// solution's content address.
+///
+/// This collects all yielded content addresses into a `Vec`, sorts them and then
+/// hashes the result to produce the solution address.
+///
+/// If you have already collected the content address for each `SolutionData` into a
+/// slice, consider [`from_data_addrs_slice`].
+pub fn from_data_addrs(data_addrs: impl IntoIterator<Item = ContentAddress>) -> ContentAddress {
+    let mut data_addrs: Vec<_> = data_addrs.into_iter().collect();
+    from_data_addrs_slice(&mut data_addrs)
+}
+
+/// Given the content address for each `SolutionData` in the `Solution`, produce the
+/// solution's content address.
+///
+/// This first sorts `data_addrs` before producing the content address of the
+/// slice, ensuring that the address maintains "solution" semantics (i.e. the order
+/// of its inner `SolutionData` does not matter).
+pub fn from_data_addrs_slice(data_addrs: &mut [ContentAddress]) -> ContentAddress {
+    data_addrs.sort();
+    ContentAddress(crate::hash_bytes_iter(
+        data_addrs.iter().map(|addr| &addr.0[..]),
+    ))
+}

--- a/crates/hash/tests/hash.rs
+++ b/crates/hash/tests/hash.rs
@@ -51,11 +51,6 @@ fn test_content_addr() {
     let content_addr = essential_hash::content_addr(&contract);
     assert_eq!(content_addr, addr);
 
-    let solution = Solution { data: vec![] };
-    let addr = essential_hash::hash(&solution);
-    let content_addr = essential_hash::content_addr(&solution);
-    assert_eq!(content_addr.0, addr);
-
     let solutions = vec![
         Solution {
             data: vec![SolutionData {


### PR DESCRIPTION
## `Solution` address

Currently, `Solution`'s implementation of `Address` means that different orderings of the same set of `SolutionData` will result in different `ContentAddress`es.

Two `Solution`s with the same `SolutionData`s in different orderings should be semantically equivalent, as `Solution`s are sets of `SolutionData`.

This changes the `Solution`'s `Address` implementation to hash over the inner `SolutionData` in order of their address, similar to how a `Contract`'s address is produced by hashing its `Predicate`s ordered by their `ContentAddress`es. As a result, two `Solution`s with the same `SolutionData` stored in different orders will now produce the same `ContentAddress`.

## `SolutionData` address

As a part of this work, a `SolutionData` `Address` implementation has been added.

`SolutionData` has a similar issue, where the order of its `state_mutations` would affect its address if we were to hash them in the stored order. In practise, a `SolutionData`'s `state_mutations` are actually a set, and their order within the `Vec` should have no impact on the protocol or the `SolutionData`s address.

To account for this, we take a similar approach for `SolutionData`'s `Address` implementation and hash the `state_mutations` ordered by `Key`.

Currently, the `SolutionData` address has no use beyond being an intermediary step in the `Solution` address calculation, but it does kind of open the ability to query for inclusion of individual `SolutionData`s in a future where blocks may be built from many merged `Solution`s.

## Simplifies Downstream

This solves some issues downstream where currently we must reliably store the order in which `SolutionData` and their `state_mutation`s appear in `Solution`s in order to be able to reliably reproduce them and in turn reliably reproduce `Block`s with the same `ContentAddress` in which they were inserted. See 
https://github.com/essential-contributions/essential-node/pull/146.

This PR removes the need to store the order of `SolutionData` and their `state_mutations`, as different orders will now result in the same `ContentAddress` anyway.

---

Sidenote: This almost allows us to remove `postcard` entirely - the only remaining usage appears to be within the `Block`'s `Address` implementation where we use it to hash the block header. We could fairly easy change this and manually hash the header and remove our dependency on `postcard` entirely? Probably best for follow-up work though.