### PR TITLE
feat: Publish new versions of all essential-base crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "essential-asm-gen"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "essential-asm-spec",
  "essential-types",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "essential-asm-spec"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "essential-check"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "essential-constraint-vm",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "essential-constraint-asm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "essential-asm-gen",
  "essential-types",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "essential-constraint-vm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "ed25519-dalek",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "essential-hash"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "essential-types",
  "hex",
@@ -480,7 +480,7 @@ version = "0.1.0"
 
 [[package]]
 name = "essential-sign"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "essential-hash",
  "essential-types",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "essential-state-asm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "essential-asm-gen",
  "essential-constraint-asm",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "essential-state-read-vm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "essential-constraint-vm",
  "essential-state-asm",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "essential-types"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hex",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ repository = "https://github.com/essential-contributions/essential-base"
 [workspace.dependencies]
 criterion = "0.5"
 ed25519-dalek = "2.1.1"
-essential-asm-gen = { path = "crates/asm-gen", version = "0.5.0" }
-essential-asm-spec = { path = "crates/asm-spec", version = "0.4.0" }
-essential-constraint-asm = { path = "crates/constraint-asm", version = "0.5.0" }
-essential-constraint-vm = { path = "crates/constraint-vm", version = "0.5.0" }
-essential-hash = { path = "crates/hash", version = "0.5.0" }
-essential-sign = { path = "crates/sign", version = "0.5.0" }
-essential-state-asm = { path = "crates/state-asm", version = "0.5.0" }
-essential-state-read-vm = { path = "crates/state-read-vm", version = "0.6.0" }
-essential-types = { path = "crates/types", version = "0.4.0" }
+essential-asm-gen = { path = "crates/asm-gen", version = "0.6.0" }
+essential-asm-spec = { path = "crates/asm-spec", version = "0.5.0" }
+essential-constraint-asm = { path = "crates/constraint-asm", version = "0.6.0" }
+essential-constraint-vm = { path = "crates/constraint-vm", version = "0.6.0" }
+essential-hash = { path = "crates/hash", version = "0.6.0" }
+essential-sign = { path = "crates/sign", version = "0.6.0" }
+essential-state-asm = { path = "crates/state-asm", version = "0.6.0" }
+essential-state-read-vm = { path = "crates/state-read-vm", version = "0.7.0" }
+essential-types = { path = "crates/types", version = "0.5.0" }
 futures = "0.3" # For `state-read-vm` tests.
 hex = "0.4.3"
 postcard = { version = "1.0.10", features = ["alloc"] }

--- a/crates/asm-gen/Cargo.toml
+++ b/crates/asm-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-asm-gen"
-version = "0.5.0"
+version = "0.6.0"
 description = "proc-macro for generating Essential ASM types from spec"
 edition.workspace = true
 authors.workspace = true

--- a/crates/asm-spec/Cargo.toml
+++ b/crates/asm-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-asm-spec"
-version = "0.4.0"
+version = "0.5.0"
 description = "Parses Essential assembly specification yaml"
 edition.workspace = true
 authors.workspace = true

--- a/crates/check/Cargo.toml
+++ b/crates/check/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Core logic related to validating Essential state transitions."
 name = "essential-check"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/constraint-asm/Cargo.toml
+++ b/crates/constraint-asm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-constraint-asm"
-version = "0.5.0"
+version = "0.6.0"
 description = "Assembly operations for the essential constraint VM"
 edition.workspace = true
 authors.workspace = true

--- a/crates/constraint-vm/Cargo.toml
+++ b/crates/constraint-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-constraint-vm"
-version = "0.5.0"
+version = "0.6.0"
 description = "The Essential constraint checking VM"
 edition.workspace = true
 authors.workspace = true

--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "essential-hash"
 description = "A minimal crate containing Essential's hash method and associated pre-hash serialization implementation."
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/sign/Cargo.toml
+++ b/crates/sign/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-sign"
-version = "0.5.0"
+version = "0.6.0"
 description = "Public key cryptography for the Essential ecosystem"
 edition.workspace = true
 authors.workspace = true

--- a/crates/state-asm/Cargo.toml
+++ b/crates/state-asm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-state-asm"
-version = "0.5.0"
+version = "0.6.0"
 description = "Assembly operations for the Essential state read VM"
 edition.workspace = true
 authors.workspace = true

--- a/crates/state-read-vm/Cargo.toml
+++ b/crates/state-read-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-state-read-vm"
-version = "0.6.0"
+version = "0.7.0"
 description = "The Essential state reading VM"
 edition.workspace = true
 authors.workspace = true

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-types"
-version = "0.4.0"
+version = "0.5.0"
 description = "Base types for the Essential ecosystem"
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Bumping versions for a new release prior to updating `essential-node` to the latest base versions (required to land essential-contributions/essential-node#146) and prior to publishing new versions of the node and builder with breaking changes to the DB.

Includes:

- New `Debug` implementation for `ContentAddress` (#218)
- The new memory and stack ops (#213)