### PR TITLE
ci: Add a cargo doc job for checking lints, deny warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   cargo:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
     strategy:
       fail-fast: false
       matrix:
@@ -24,6 +26,7 @@ jobs:
           - command: test --locked --all
           - command: test --no-default-features --locked --all
           - command: test --all-features --locked --all
+          - command: doc --all-features --locked --no-deps
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
@@ -45,7 +48,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       [
         cargo,
         cargo-toml-lint,

--- a/crates/check/src/predicate.rs
+++ b/crates/check/src/predicate.rs
@@ -28,7 +28,7 @@ pub enum InvalidContract {
     Predicate(usize, InvalidPredicate),
 }
 
-/// [`check_predicate`] error.
+/// [`check`] error.
 #[derive(Debug, Error)]
 pub enum InvalidPredicate {
     /// The number of nodes in the predicate exceeds the limit.

--- a/crates/hash/src/contract_addr.rs
+++ b/crates/hash/src/contract_addr.rs
@@ -7,7 +7,7 @@
 use essential_types::{contract::Contract, ContentAddress, Hash};
 
 /// Shorthand for the common case of producing an contract address from an
-/// iterator yielding references to [`Predicate`]s.
+/// iterator yielding references to [`Predicate`][essential_types::predicate::Predicate]s.
 ///
 /// If you have already calculated the content address for each predicate consider
 /// using [`from_predicate_addrs`] or [`from_predicate_addrs_slice`].

--- a/crates/hash/src/solution_addr.rs
+++ b/crates/hash/src/solution_addr.rs
@@ -4,7 +4,7 @@
 use essential_types::{solution::Solution, ContentAddress};
 
 /// Shorthand for the common case of producing a solution address from an
-/// iterator yielding references to [`SolutionData`]s.
+/// iterator yielding references to [`SolutionData`][essential_types::solution::SolutionData]s.
 ///
 /// If you have already calculated the content address for each `SolutionData` consider
 /// using [`from_data_addrs`] or [`from_data_addrs_slice`].

--- a/crates/sign/src/contract.rs
+++ b/crates/sign/src/contract.rs
@@ -19,7 +19,7 @@ use secp256k1::{PublicKey, SecretKey};
 ///
 /// If the content address of the contract is already known, consider signing
 /// the content address directly with [`sign_hash`][crate::sign_hash] and then
-/// constructing the [`predicate::SignedContract`] from its fields.
+/// constructing the [`contract::SignedContract`] from its fields.
 pub fn sign(contract: Contract, sk: &SecretKey) -> contract::SignedContract {
     let ca = essential_hash::content_addr(&contract);
     let signature = crate::sign_hash(ca.0, sk);

--- a/crates/sign/src/lib.rs
+++ b/crates/sign/src/lib.rs
@@ -2,15 +2,6 @@
 //! and public key recovery functions implemented using [`secp256k1`] and the
 //! [`essential_hash`] crate.
 //!
-//! ## Signing Arbitrary Data
-//!
-//! For signing arbitrary data, the following take care of hashing the data in a
-//! consistent manner internally.
-//!
-//! - [`sign`]
-//! - [`verify`]
-//! - [`recover`]
-//!
 //! ## Signing Hashes
 //!
 //! In cases where the `Hash` (or `ContentAddress`) is already known, the following
@@ -36,11 +27,6 @@ pub mod encode;
 /// Sign directly over a hash with the given secret key using `secp256k1`.
 ///
 /// This treats the hash as a digest from which a [`Message`] is produced and then signed.
-///
-/// If you plan to use the resulting `Signature` with [`verify`] or [`recover`]
-/// to verify a signature or recover a public key over some arbitrary data, the
-/// given `hash` must be produced by [`essential_hash::hash`] (i.e. be a sha256
-/// hash).
 pub fn sign_hash(hash: Hash, sk: &SecretKey) -> Signature {
     let message = Message::from_digest(hash);
     sign_message(&message, sk)
@@ -56,7 +42,7 @@ fn sign_message(msg: &Message, sk: &SecretKey) -> Signature {
 /// Verify a signature over the given hash.
 ///
 /// This treats the given hash as a digest for a [`Message`] that is verified
-/// with [`verify_message`].
+/// with `verify_message`.
 pub fn verify_hash(hash: Hash, signature: &Signature) -> Result<(), secp256k1::Error> {
     let msg = Message::from_digest(hash);
     verify_message(&msg, signature)

--- a/crates/vm/src/cached.rs
+++ b/crates/vm/src/cached.rs
@@ -1,14 +1,12 @@
-use std::{collections::HashSet, sync::OnceLock};
-
-use essential_types::{solution::SolutionData, Hash};
-
 use crate::access::init_predicate_exists;
+use essential_types::{solution::SolutionData, Hash};
+use std::{collections::HashSet, sync::OnceLock};
 
 #[derive(Default, Debug, PartialEq)]
 /// Lazily cache expensive to compute values.
 pub struct LazyCache {
     /// Decision variables and addresses set of hashes.
-    /// See [`PredicateExists`][essential_constraint_asm::Op] for more details.
+    /// See [`PredicateExists`][essential_asm] for more details.
     pub dec_var_hashes: OnceLock<HashSet<Hash>>,
 }
 

--- a/crates/vm/src/lib.rs
+++ b/crates/vm/src/lib.rs
@@ -4,11 +4,10 @@
 //!
 //! The primary entrypoint for this crate is the [`Vm` type][Vm].
 //!
-//! The `Vm` allows for executing operations that read state and apply any
-//! necessary operations in order to form the final, expected state slot layout
-//! within the VM's [`Memory`]. The `Vm`'s memory can be accessed directly
-//! from the `Vm`, or the `Vm` can be consumed and state slots returned with
-//! [`Vm::into_state_slots`].
+//! The `Vm` allows for executing arbitrary [essential ASM][asm] ops.
+//! The primary use-case is executing [`Program`][essential_types::predicate::Program]s
+//! that make up a [`Predicate`][essential_types::predicate::Predicate]'s program graph
+//! during [`Solution`][essential_types::solution::Solution] validation.
 //!
 //! ## Executing Ops
 //!


### PR DESCRIPTION
Also addresses some doc issues currently present in `cargo doc` warnings.

This PR is against #212 as #212 is pretty close to landing and this avoids the need for another rebase onto `main`.

Closes #231 