### PR TITLE
feat: Change `Memory::Free` to allow specifying a new `len` equal to current `memory.len()`

### DIFF
--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -491,10 +491,11 @@ Op:
 
         Free:
           opcode: 0x71
-          description: Free memory down to the specified index.
+          description: Truncate memory to the specified new length, freeing all that follows.
           panics:
-            - The index is negative.
-          stack_in: [index]
+            - The new length is negative.
+            - The new length is greater than the existing length.
+          stack_in: [new_length]
 
         Load:
           opcode: 0x72

--- a/crates/vm/src/memory.rs
+++ b/crates/vm/src/memory.rs
@@ -70,13 +70,13 @@ impl Memory {
         Ok(self.0[address..end].to_vec())
     }
 
-    /// Free some memory from an index to the end of this memory.
-    pub fn free(&mut self, address: Word) -> Result<(), MemoryError> {
-        let index = usize::try_from(address).map_err(|_| MemoryError::IndexOutOfBounds)?;
-        if index >= self.0.len() {
+    /// Truncate memory to the given `new_len`, freeing all memory that follows.
+    pub fn free(&mut self, new_len: Word) -> Result<(), MemoryError> {
+        let new_len = usize::try_from(new_len).map_err(|_| MemoryError::IndexOutOfBounds)?;
+        if new_len > self.0.len() {
             return Err(MemoryError::IndexOutOfBounds);
         }
-        self.0.truncate(index);
+        self.0.truncate(new_len);
         self.0.shrink_to_fit();
         Ok(())
     }

--- a/crates/vm/src/memory/tests.rs
+++ b/crates/vm/src/memory/tests.rs
@@ -28,12 +28,12 @@ fn test_free_empty_memory() {
     let mut memory = Memory::new();
     assert!(memory.is_empty());
 
-    // Trying to free address 0 from empty memory should fail
-    assert!(matches!(memory.free(0), Err(MemoryError::IndexOutOfBounds)));
+    // Trying to free when `new_len` is equal to `memory.len()` is a no-op.
+    memory.free(0).unwrap();
 }
 
 #[test]
-fn test_free_valid_address() {
+fn test_free_valid_new_len() {
     let mut memory = Memory::new();
 
     // Allocate 10 words
@@ -45,7 +45,7 @@ fn test_free_valid_address() {
         memory.store(i, i as Word).unwrap();
     }
 
-    // Free from index 5
+    // Free all beyond len 5.
     memory.free(5).unwrap();
 
     // Verify new length
@@ -89,14 +89,14 @@ fn test_free_at_start() {
 }
 
 #[test]
-fn test_free_invalid_address() {
+fn test_free_invalid_new_len() {
     let mut memory = Memory::new();
     memory.alloc(5).unwrap();
 
-    // Test with out of bounds index
-    assert!(matches!(memory.free(5), Err(MemoryError::IndexOutOfBounds)));
+    // Test with out of bounds new length
+    assert!(matches!(memory.free(6), Err(MemoryError::IndexOutOfBounds)));
 
-    // Test with very large index
+    // Test with very large new length
     assert!(matches!(
         memory.free(Word::MAX),
         Err(MemoryError::IndexOutOfBounds)
@@ -107,7 +107,7 @@ fn test_free_invalid_address() {
 }
 
 #[test]
-fn test_free_negative_address() {
+fn test_free_negative_new_len() {
     let mut memory = Memory::new();
     memory.alloc(5).unwrap();
 


### PR DESCRIPTION
This is useful for cases where we're freeing down to some dynamically known length which may or may not be empty.

Freeing down to a length that is equal to the current length is a no-op.

Addresses [this comment](https://github.com/essential-contributions/essential-base/pull/212#discussion_r1861205717).