### PR TITLE
feat: Bump all crate versions, ready for publishing DAG changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "essential-asm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bitflags",
  "essential-asm-gen",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "essential-asm-gen"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "essential-asm-spec",
  "essential-types",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "essential-asm-spec"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "essential-check"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "essential-hash",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "essential-hash"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "essential-types",
  "hex",
@@ -467,7 +467,7 @@ version = "0.1.0"
 
 [[package]]
 name = "essential-sign"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "essential-hash",
  "essential-types",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "essential-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "hex",
  "schemars",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "essential-vm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ repository = "https://github.com/essential-contributions/essential-base"
 bitflags = "2.6"
 criterion = "0.5"
 ed25519-dalek = "2.1.1"
-essential-asm = { path = "crates/asm", version = "0.6.0" }
-essential-asm-gen = { path = "crates/asm-gen", version = "0.6.0" }
-essential-asm-spec = { path = "crates/asm-spec", version = "0.5.0" }
-essential-hash = { path = "crates/hash", version = "0.7.0" }
-essential-sign = { path = "crates/sign", version = "0.7.0" }
-essential-types = { path = "crates/types", version = "0.5.0" }
-essential-vm = { path = "crates/vm", version = "0.7.0" }
+essential-asm = { path = "crates/asm", version = "0.7.0" }
+essential-asm-gen = { path = "crates/asm-gen", version = "0.7.0" }
+essential-asm-spec = { path = "crates/asm-spec", version = "0.6.0" }
+essential-hash = { path = "crates/hash", version = "0.8.0" }
+essential-sign = { path = "crates/sign", version = "0.8.0" }
+essential-types = { path = "crates/types", version = "0.6.0" }
+essential-vm = { path = "crates/vm", version = "0.8.0" }
 futures = "0.3" # For `state-read-vm` tests.
 hex = "0.4.3"
 postcard = { version = "1.0.10", features = ["alloc"] }

--- a/crates/asm-gen/Cargo.toml
+++ b/crates/asm-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-asm-gen"
-version = "0.6.0"
+version = "0.7.0"
 description = "proc-macro for generating Essential ASM types from spec"
 edition.workspace = true
 authors.workspace = true

--- a/crates/asm-spec/Cargo.toml
+++ b/crates/asm-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-asm-spec"
-version = "0.5.0"
+version = "0.6.0"
 description = "Parses Essential assembly specification yaml"
 edition.workspace = true
 authors.workspace = true

--- a/crates/asm/Cargo.toml
+++ b/crates/asm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-asm"
-version = "0.6.0"
+version = "0.7.0"
 description = "Assembly operations for the Essential VM"
 edition.workspace = true
 authors.workspace = true

--- a/crates/check/Cargo.toml
+++ b/crates/check/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Core logic related to validating Essential state transitions."
 name = "essential-check"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "essential-hash"
 description = "A minimal crate containing Essential's hash method and associated pre-hash serialization implementation."
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/sign/Cargo.toml
+++ b/crates/sign/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-sign"
-version = "0.7.0"
+version = "0.8.0"
 description = "Public key cryptography for the Essential ecosystem"
 edition.workspace = true
 authors.workspace = true

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-types"
-version = "0.5.0"
+version = "0.6.0"
 description = "Base types for the Essential ecosystem"
 edition.workspace = true
 authors.workspace = true

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-vm"
-version = "0.7.0"
+version = "0.8.0"
 description = "The Essential VM"
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
This prepares the `develop` branch to auto-publish all of the changes under new crate versions when we merge it into `main`.