### PR TITLE
Reserve returns the index where the reserved space starts

### DIFF
--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -103,7 +103,9 @@ Op:
           description: |
             Reserve space on the stack for `len` words.
             The reserved space is set to 0.
+            Returns the index to the start of the reserved space.
           stack_in: [len]
+          stack_out: [index]
 
         Load:
           opcode: 0x0C

--- a/crates/vm/src/stack.rs
+++ b/crates/vm/src/stack.rs
@@ -45,11 +45,14 @@ impl Stack {
     pub(crate) fn reserve_zeroed(&mut self) -> StackResult<()> {
         let len = self.pop()?;
         let len = usize::try_from(len).map_err(|_| StackError::IndexOutOfBounds)?;
-        let new_len = self.len().saturating_add(len);
+        let start = self.len();
+        let new_len = start.saturating_add(len);
         if new_len > Self::SIZE_LIMIT {
             return Err(StackError::IndexOutOfBounds);
         }
         self.0.resize(new_len, 0);
+        let start = Word::try_from(start).map_err(|_| StackError::IndexOutOfBounds)?;
+        self.push(start)?;
         Ok(())
     }
 

--- a/crates/vm/src/stack/frame_tests.rs
+++ b/crates/vm/src/stack/frame_tests.rs
@@ -13,10 +13,10 @@ fn setup_stack(values: &[Word]) -> Stack {
 fn test_reserve_zeroed_success() {
     let mut stack = setup_stack(&[3]); // Push length 3
     assert!(stack.reserve_zeroed().is_ok());
-    assert_eq!(stack.0, vec![0, 0, 0]);
+    assert_eq!(stack.0, vec![0, 0, 0, 0]);
     stack.push(2).unwrap(); // Push length 2
     assert!(stack.reserve_zeroed().is_ok());
-    assert_eq!(stack.0, vec![0, 0, 0, 0, 0]);
+    assert_eq!(stack.0, vec![0, 0, 0, 0, 0, 0, 4]);
 }
 
 #[test]
@@ -44,6 +44,13 @@ fn test_reserve_zeroed_exceeds_size_limit() {
         stack.reserve_zeroed().unwrap_err(),
         StackError::IndexOutOfBounds
     ));
+}
+
+#[test]
+fn test_reserve_zero_gives_stack_len() {
+    let mut stack = setup_stack(&[1, 2, 3, 0]); // Push length 3
+    assert!(stack.reserve_zeroed().is_ok());
+    assert_eq!(stack.0, vec![1, 2, 3, 3]);
 }
 
 #[test]


### PR DESCRIPTION
<!-- ps-id: d149c938-f51a-41c9-bb93-3e0f469a34fe -->
Simple PR that just returns the position of the start of the newly reserved space.
Can also be used to get the length of the stack by reserving zero