### PR TITLE
Add drop from stack op

### DIFF
--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -129,6 +129,12 @@ Op:
           panics:
             - Index is out of range.
           stack_in: [value, index]
+        
+        Drop:
+          opcode: 0x0E
+          short: DROP
+          description: Drop the top `n` elements from the stack.
+          stack_in: [n]
 
     Pred:
       description: Operations for computing predicates.

--- a/crates/vm/src/sync.rs
+++ b/crates/vm/src/sync.rs
@@ -238,6 +238,7 @@ pub fn step_op_stack(
         return Ok(repeat.repeat()?.map(ProgramControlFlow::Pc));
     }
     let r = match op {
+        asm::Stack::Drop => stack.pop_len_words(|_| Ok(())),
         asm::Stack::Dup => stack.pop1_push2(|w| Ok([w, w])),
         asm::Stack::DupFrom => stack.dup_from().map_err(From::from),
         asm::Stack::Push(word) => stack.push(word).map_err(From::from),


### PR DESCRIPTION
<!-- ps-id: bcf2d79c-0fca-45ec-82f6-7ea779e1dc72 -->
Adds an op to drop n from the top of the stack. Useful for clearing reserved space