### PR TITLE
feat: Add `ParentMemory` `Load`, `LoadRange` ops and impl in anticipation of `Compute` op

### DIFF
--- a/crates/asm-spec/asm.yml
+++ b/crates/asm-spec/asm.yml
@@ -542,6 +542,30 @@ Op:
             - Index + len is out of bounds.
           stack_in: [values, len, index]
 
+    ParentMemory:
+      description: Operations for reading parent memory from within a compute context.
+      group:
+        Load:
+          opcode: 0x7A
+          short: PLOD
+          description: Load the value at the given index from parent memory onto the stack.
+          panics:
+            - Not in compute context.
+            - Index is out of bounds.
+          stack_in: [index]
+          stack_out: [value]
+
+        LoadRange:
+          opcode: 0x7B
+          short: PLODR
+          description: Load a range of words starting at the index within parent memory.
+          panics:
+            - Not in compute context.
+            - Index is out of bounds.
+            - Index + len is out of bounds.
+          stack_in: [index, len]
+          stack_out: [values]
+
     StateRead:
       description: Operations related to reading state.
       group:

--- a/crates/vm/src/error.rs
+++ b/crates/vm/src/error.rs
@@ -124,8 +124,11 @@ pub enum OpSyncError {
     #[error("total control flow operation error: {0}")]
     TotalControlFlow(#[from] TotalControlFlowError),
     /// An error occurred during a `Memory` operation.
-    #[error("temporary operation error: {0}")]
+    #[error("memory operation error: {0}")]
     Memory(#[from] MemoryError),
+    /// An error occurred during a `ParentMemory` operation.
+    #[error("parent memory operation error: {0}")]
+    ParentMemory(#[from] ParentMemoryError),
     /// An error occurred while parsing an operation from bytes.
     #[error("bytecode error: {0}")]
     FromBytes(#[from] asm::FromBytesError),
@@ -350,6 +353,17 @@ pub enum MemoryError {
     /// The memory size exceeded the size limit.
     #[error("the {}-word stack size limit was exceeded", crate::Memory::SIZE_LIMIT)]
     Overflow,
+}
+
+/// Parent memory operation error.
+#[derive(Debug, Error)]
+pub enum ParentMemoryError {
+    /// Attempted to access parent memory outside of a `Compute` context.
+    #[error("Attempted to access parent memory outside of a `Compute` context")]
+    NoParent,
+    /// A memory access error occurred.
+    #[error("A memory access error occurred: {0}")]
+    Memory(#[from] MemoryError),
 }
 
 /// Decode error.

--- a/crates/vm/src/lib.rs
+++ b/crates/vm/src/lib.rs
@@ -113,6 +113,8 @@ pub enum OpSync {
     Crypto(asm::Crypto),
     /// `[asm::Memory]` operations.
     Memory(asm::Memory),
+    /// `[asm::ParentMemory]` operations.
+    ParentMemory(asm::ParentMemory),
     /// `[asm::Pred]` operations.
     Pred(asm::Pred),
     /// `[asm::Stack]` operations.
@@ -145,6 +147,7 @@ impl From<Op> for OpKind {
             Op::Alu(op) => OpKind::Sync(OpSync::Alu(op)),
             Op::Crypto(op) => OpKind::Sync(OpSync::Crypto(op)),
             Op::Memory(op) => OpKind::Sync(OpSync::Memory(op)),
+            Op::ParentMemory(op) => OpKind::Sync(OpSync::ParentMemory(op)),
             Op::Pred(op) => OpKind::Sync(OpSync::Pred(op)),
             Op::Stack(op) => OpKind::Sync(OpSync::Stack(op)),
             Op::StateRead(op) => OpKind::Async(OpAsync(op)),

--- a/crates/vm/src/memory.rs
+++ b/crates/vm/src/memory.rs
@@ -41,7 +41,7 @@ impl Memory {
     }
 
     /// Load a word from the given address.
-    pub fn load(&mut self, address: Word) -> Result<Word, MemoryError> {
+    pub fn load(&self, address: Word) -> Result<Word, MemoryError> {
         let index = usize::try_from(address).map_err(|_| MemoryError::IndexOutOfBounds)?;
         Ok(*self.0.get(index).ok_or(MemoryError::IndexOutOfBounds)?)
     }
@@ -60,7 +60,7 @@ impl Memory {
     }
 
     /// Load a range of words starting at the given address.
-    pub fn load_range(&mut self, address: Word, size: Word) -> Result<Vec<Word>, MemoryError> {
+    pub fn load_range(&self, address: Word, size: Word) -> Result<Vec<Word>, MemoryError> {
         let address = usize::try_from(address).map_err(|_| MemoryError::IndexOutOfBounds)?;
         let size = usize::try_from(size).map_err(|_| MemoryError::Overflow)?;
         let end = address.checked_add(size).ok_or(MemoryError::Overflow)?;

--- a/crates/vm/src/memory/tests.rs
+++ b/crates/vm/src/memory/tests.rs
@@ -366,7 +366,7 @@ fn test_store_range_after_free() {
 
 #[test]
 fn test_load_range_empty_memory() {
-    let mut memory = Memory::new();
+    let memory = Memory::new();
 
     // Trying to load from empty memory should fail
     assert!(matches!(

--- a/crates/vm/src/sync.rs
+++ b/crates/vm/src/sync.rs
@@ -4,11 +4,13 @@ use crate::{
     access, alu, asm, crypto,
     error::{
         EvalSyncError, EvalSyncResult, ExecSyncError, ExecSyncResult, OpSyncError, OpSyncResult,
+        ParentMemoryError,
     },
     pred, repeat, total_control_flow,
     types::convert::bool_from_word,
     Access, LazyCache, Memory, OpAccess, OpSync, ProgramControlFlow, Repeat, Stack, Vm,
 };
+use std::sync::Arc;
 
 impl From<asm::Access> for OpSync {
     fn from(op: asm::Access) -> Self {
@@ -89,12 +91,21 @@ where
     let mut pc = 0;
     let mut stack = Stack::default();
     let mut memory = Memory::new();
+    let parent_memory = &[];
     let mut repeat = Repeat::new();
     let cache = LazyCache::new();
     while let Some(res) = op_access.op_access(pc) {
         let op = res.map_err(|err| ExecSyncError(pc, err.into()))?;
-
-        let res = step_op(access, op, &mut stack, &mut memory, pc, &mut repeat, &cache);
+        let res = step_op(
+            access,
+            op,
+            &mut stack,
+            &mut memory,
+            parent_memory,
+            pc,
+            &mut repeat,
+            &cache,
+        );
 
         #[cfg(feature = "tracing")]
         crate::trace_op_res(&mut op_access, pc, &stack, &memory, res.as_ref());
@@ -123,10 +134,11 @@ pub fn step_op_sync(op: OpSync, access: Access, vm: &mut Vm) -> OpSyncResult<Opt
         repeat,
         pc,
         memory,
+        parent_memory,
         cache,
         ..
     } = vm;
-    match step_op(access, op, stack, memory, *pc, repeat, cache)? {
+    match step_op(access, op, stack, memory, parent_memory, *pc, repeat, cache)? {
         Some(ProgramControlFlow::Pc(pc)) => return Ok(Some(pc)),
         Some(ProgramControlFlow::Halt) => return Ok(None),
         None => (),
@@ -142,6 +154,7 @@ pub fn step_op(
     op: OpSync,
     stack: &mut Stack,
     memory: &mut Memory,
+    parent_memory: &[Arc<Memory>],
     pc: usize,
     repeat: &mut Repeat,
     cache: &LazyCache,
@@ -154,6 +167,7 @@ pub fn step_op(
         OpSync::Stack(op) => step_op_stack(op, pc, stack, repeat),
         OpSync::ControlFlow(op) => step_op_total_control_flow(op, stack, pc),
         OpSync::Memory(op) => step_op_memory(op, stack, memory).map(|_| None),
+        OpSync::ParentMemory(op) => step_op_parent_memory(op, stack, parent_memory).map(|_| None),
     }
 }
 
@@ -305,6 +319,28 @@ pub fn step_op_memory(op: asm::Memory, stack: &mut Stack, memory: &mut Memory) -
                 Ok::<_, OpSyncError>(())
             })?;
             Ok(())
+        }
+    }
+}
+
+/// Step forward execution by the given parent memory operation.
+pub fn step_op_parent_memory(
+    op: asm::ParentMemory,
+    stack: &mut Stack,
+    parent_memory: &[Arc<Memory>],
+) -> OpSyncResult<()> {
+    let Some(memory) = parent_memory.last() else {
+        return Err(ParentMemoryError::NoParent.into());
+    };
+    match op {
+        asm::ParentMemory::Load => stack.pop1_push1(|addr| {
+            let w = memory.load(addr)?;
+            Ok(w)
+        }),
+        asm::ParentMemory::LoadRange => {
+            let [addr, size] = stack.pop2()?;
+            let words = memory.load_range(addr, size)?;
+            Ok(stack.extend(words)?)
         }
     }
 }

--- a/crates/vm/src/vm.rs
+++ b/crates/vm/src/vm.rs
@@ -5,6 +5,7 @@ use crate::{
     future, Access, BytecodeMapped, BytecodeMappedLazy, Gas, GasLimit, LazyCache, Memory, Op,
     OpAccess, OpGasCost, Repeat, Stack, StateRead,
 };
+use std::sync::Arc;
 
 /// The operation execution state of the VM.
 #[derive(Debug, Default, PartialEq)]
@@ -15,6 +16,13 @@ pub struct Vm {
     pub stack: Stack,
     /// The memory for temporary storage of words.
     pub memory: Memory,
+    /// The stack of parent `Memory`s.
+    ///
+    /// This is empty at the beginning of execution, but is pushed to each time
+    /// we enter a [`Compute`] op context with the parent's `Memory`.
+    ///
+    /// This can also be used to observe the `Compute` op depth.
+    pub parent_memory: Vec<Arc<Memory>>,
     /// The repeat stack.
     pub repeat: Repeat,
     /// Lazily cached data for the VM.


### PR DESCRIPTION
This is a part of progress on the `Compute` op implementation (see #259).

Closes #260.
Closes #261.

## To-Do

- [ ] Add tests for `ParentMemory` ops.