### PR TITLE
furnic/verify message improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "essential-check"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "essential-hash",
@@ -467,7 +467,7 @@ version = "0.1.0"
 
 [[package]]
 name = "essential-sign"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "essential-hash",
  "essential-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ essential-asm = { path = "crates/asm", version = "0.9.0" }
 essential-asm-gen = { path = "crates/asm-gen", version = "0.9.0" }
 essential-asm-spec = { path = "crates/asm-spec", version = "0.7.0" }
 essential-hash = { path = "crates/hash", version = "0.9.0" }
-essential-sign = { path = "crates/sign", version = "0.10.0" }
+essential-sign = { path = "crates/sign", version = "0.11.0" }
 essential-types = { path = "crates/types", version = "0.7.0" }
 essential-vm = { path = "crates/vm", version = "0.11.0" }
 futures = "0.3" # For `state-read-vm` tests.

--- a/crates/check/Cargo.toml
+++ b/crates/check/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Core logic related to validating Essential state transitions."
 name = "essential-check"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/sign/Cargo.toml
+++ b/crates/sign/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-sign"
-version = "0.10.0"
+version = "0.11.0"
 description = "Public key cryptography for the Essential ecosystem"
 edition.workspace = true
 authors.workspace = true

--- a/crates/sign/src/lib.rs
+++ b/crates/sign/src/lib.rs
@@ -52,11 +52,11 @@ pub fn verify_hash(hash: Hash, signature: &Signature) -> Result<(), secp256k1::E
 /// Verify the given [`PublicKey`] against the message & signature.
 pub fn verify_message(
     msg: &Message,
-    sig: &Signature,
+    sig_bytes: &[u8; 64],
     pk: &PublicKey,
 ) -> Result<(), secp256k1::Error> {
     let secp = Secp256k1::verification_only();
-    let compact_sig = CompactSignature::from_compact(&sig.0)?;
+    let compact_sig = CompactSignature::from_compact(sig_bytes)?;
     secp.verify_ecdsa(msg, &compact_sig, pk)
 }
 

--- a/crates/sign/tests/sign.rs
+++ b/crates/sign/tests/sign.rs
@@ -58,6 +58,6 @@ fn verify_pubkey() {
     let msg = Message::from_digest(hash);
     let signed_message = sign_message(&msg, &sk);
 
-    assert!(essential_sign::verify_message(&msg, &signed_message, &pk).is_ok());
-    assert!(essential_sign::verify_message(&msg, &signed_message, &pk2).is_err());
+    assert!(essential_sign::verify_message(&msg, &signed_message.0, &pk).is_ok());
+    assert!(essential_sign::verify_message(&msg, &signed_message.0, &pk2).is_err());
 }


### PR DESCRIPTION
- improvement: adust fn sig to take just sig.0 bytes
- chore: bump crate versions for publishing
