### PR TITLE
Adds encoding and decoding for mutations and lists of mutations.

### DIFF
--- a/crates/types/src/fmt.rs
+++ b/crates/types/src/fmt.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     predicate::{PredicateDecodeError, PredicateEncodeError},
+    solution::decode::MutationDecodeError,
     ContentAddress, PredicateAddress, Signature,
 };
 use core::{fmt, str};
@@ -89,6 +90,19 @@ impl fmt::Display for PredicateEncodeError {
             match self {
                 PredicateEncodeError::TooManyNodes => "too many nodes",
                 PredicateEncodeError::TooManyEdges => "too many edges",
+            }
+        )
+    }
+}
+
+impl fmt::Display for MutationDecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                MutationDecodeError::BytesTooShort =>
+                    "bytes too short for lengths given for key or value",
             }
         )
     }

--- a/crates/types/src/solution/decode.rs
+++ b/crates/types/src/solution/decode.rs
@@ -1,0 +1,79 @@
+//! # Decoding
+//! Decoding for solution types.
+
+use crate::Word;
+
+use super::Mutation;
+
+#[cfg(test)]
+mod tests;
+
+/// Errors that can occur when decoding a predicate.
+#[derive(Debug, PartialEq)]
+pub enum MutationDecodeError {
+    /// The bytes are too short for the lengths of the key or value.
+    BytesTooShort,
+}
+
+impl std::error::Error for MutationDecodeError {}
+
+/// Decode a mutation from words.
+///
+/// # Layout
+/// ```text
+/// +-----------------+-----------------+
+/// | key length      | key             |
+/// +-----------------+-----------------+
+/// | value length    | value           |
+/// +-----------------+-----------------+
+/// ```
+pub fn decode_mutation(bytes: &[Word]) -> Result<Mutation, MutationDecodeError> {
+    if bytes.len() < 2 {
+        return Err(MutationDecodeError::BytesTooShort);
+    }
+    // Saturating cast
+    let key_len: usize = bytes[0].try_into().unwrap_or(usize::MAX);
+    if bytes.len() < 1 + key_len {
+        return Err(MutationDecodeError::BytesTooShort);
+    }
+    let key = bytes[1..1 + key_len].to_vec();
+    // Saturating cast
+    let value_len: usize = bytes[1 + key_len].try_into().unwrap_or(usize::MAX);
+
+    if bytes.len() < 2 + key_len + value_len {
+        return Err(MutationDecodeError::BytesTooShort);
+    }
+    let value = bytes[2 + key_len..2 + key_len + value_len].to_vec();
+    Ok(Mutation { key, value })
+}
+
+/// Decode a slice of mutations from words.
+///
+/// # Layout
+/// ```text
+/// +-----------------+-----------------+-----------------+-----------------+
+/// | num mutations   | mutation 1      | mutation 2      | ...             |
+/// +-----------------+-----------------+-----------------+-----------------+
+/// ```
+pub fn decode_mutations(bytes: &[Word]) -> Result<Vec<Mutation>, MutationDecodeError> {
+    if bytes.is_empty() {
+        return Err(MutationDecodeError::BytesTooShort);
+    }
+    // Saturating cast
+    let len: usize = bytes[0].try_into().unwrap_or(usize::MAX);
+    let mut mutations = Vec::with_capacity(len);
+    if len == 0 {
+        return Ok(mutations);
+    }
+    let mut i = 1;
+    while i < bytes.len() {
+        let Some(b) = bytes.get(i..) else {
+            return Err(MutationDecodeError::BytesTooShort);
+        };
+        let mutation = decode_mutation(b)?;
+        let size = mutation.encode_size();
+        i += size;
+        mutations.push(mutation);
+    }
+    Ok(mutations)
+}

--- a/crates/types/src/solution/decode/tests.rs
+++ b/crates/types/src/solution/decode/tests.rs
@@ -1,0 +1,23 @@
+use super::*;
+
+#[test]
+fn test_decode_mutation() {
+    let words = vec![3, 1, 2, 3, 2, 4, 5];
+    let m = decode_mutation(&words).unwrap();
+    assert_eq!(m.key, vec![1, 2, 3]);
+    assert_eq!(m.value, vec![4, 5]);
+
+    let words = vec![4, 1, 2, 3, 2, 4, 5];
+    decode_mutation(&words).expect_err("Value length too short");
+}
+
+#[test]
+fn test_decode_mutations() {
+    let words = vec![2, 3, 1, 2, 3, 2, 4, 5, 2, 6, 7, 3, 8, 9, 10];
+    let m = decode_mutations(&words).unwrap();
+    assert_eq!(m.len(), 2);
+    assert_eq!(m[0].key, vec![1, 2, 3]);
+    assert_eq!(m[0].value, vec![4, 5]);
+    assert_eq!(m[1].key, vec![6, 7]);
+    assert_eq!(m[1].value, vec![8, 9, 10]);
+}

--- a/crates/types/src/solution/encode.rs
+++ b/crates/types/src/solution/encode.rs
@@ -1,0 +1,51 @@
+//! # Encoding
+//! Encoding for solution types.
+use crate::Word;
+
+use super::Mutation;
+
+#[cfg(test)]
+mod tests;
+
+/// Returns the size in words of the encoded mutation.
+///
+/// 2 words for the key length and value length,
+/// plus the length of the key and value data.
+pub fn encode_mutation_size(mutation: &Mutation) -> usize {
+    2 + mutation.key.len() + mutation.value.len()
+}
+
+/// Encodes a mutation into a sequence of words.
+///
+/// # Layout
+/// ```text
+/// +-----------------+-----------------+
+/// | key length      | key             |
+/// +-----------------+-----------------+
+/// | value length    | value           |
+/// +-----------------+-----------------+
+/// ```
+pub fn encode_mutation(mutation: &Mutation) -> impl Iterator<Item = Word> + use<'_> {
+    // Saturating cast
+    let key_len: Word = mutation.key.len().try_into().unwrap_or(Word::MAX);
+    // Saturating cast
+    let value_len: Word = mutation.value.len().try_into().unwrap_or(Word::MAX);
+    std::iter::once(key_len)
+        .chain(mutation.key.iter().copied())
+        .chain(std::iter::once(value_len))
+        .chain(mutation.value.iter().copied())
+}
+
+/// Encodes a slice of mutations into a sequence of words.
+///
+/// # Layout
+/// ```text
+/// +-----------------+-----------------+-----------------+-----------------+
+/// | num mutations   | mutation 1      | mutation 2      | ...             |
+/// +-----------------+-----------------+-----------------+-----------------+
+/// ```
+pub fn encode_mutations(mutations: &[Mutation]) -> impl Iterator<Item = Word> + use<'_> {
+    // Saturating cast
+    let len: Word = mutations.len().try_into().unwrap_or(Word::MAX);
+    std::iter::once(len).chain(mutations.iter().flat_map(encode_mutation))
+}

--- a/crates/types/src/solution/encode/tests.rs
+++ b/crates/types/src/solution/encode/tests.rs
@@ -1,0 +1,38 @@
+use crate::solution::decode::{decode_mutation, decode_mutations};
+
+use super::*;
+
+#[test]
+fn test_encode_mutation() {
+    let m = Mutation {
+        key: vec![1, 2, 3],
+        value: vec![4, 5],
+    };
+    let words = encode_mutation(&m).collect::<Vec<_>>();
+    assert_eq!(words, vec![3, 1, 2, 3, 2, 4, 5]);
+
+    // Round trip
+    let m2 = decode_mutation(&words).unwrap();
+    assert_eq!(m, m2);
+}
+
+#[test]
+fn test_encode_mutations() {
+    let m = vec![
+        Mutation {
+            key: vec![1, 2, 3],
+            value: vec![4, 5],
+        },
+        Mutation {
+            key: vec![6, 7],
+            value: vec![8, 9, 10],
+        },
+    ];
+
+    let words = encode_mutations(&m).collect::<Vec<_>>();
+    assert_eq!(words, vec![2, 3, 1, 2, 3, 2, 4, 5, 2, 6, 7, 3, 8, 9, 10]);
+
+    // Round trip
+    let m2 = decode_mutations(&words).unwrap();
+    assert_eq!(m, m2);
+}


### PR DESCRIPTION
This encodes to and from words not bytes.
Layout of a mutation is key_len, key..., value_len, value... Layout of a list of mutations is num_mutations, mutation 1, mutation 2, ...
closes #278

<!-- ps-id: 6c72cbcb-353b-4394-8910-ec62285f2c9e -->