### PR TITLE
Compute Mutations

### DIFF
--- a/crates/check/src/solution/tests.rs
+++ b/crates/check/src/solution/tests.rs
@@ -1,0 +1,103 @@
+use super::*;
+use crate::vm::asm;
+use asm::short::*;
+
+#[tokio::test]
+async fn test_program_output() {
+    // Satisfied true
+    let p = Program(asm::to_bytes([PUSH(1)]).collect());
+    let (o, _) = run_program(
+        PanicStateRead,
+        PanicStateRead,
+        empty_sol_set(),
+        0,
+        Arc::new(p),
+        empty_prgm_ctx(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(o, Some(ProgramOutput::Satisfied(true)));
+
+    // Satisfied false 0
+    let p = Program(asm::to_bytes([PUSH(0)]).collect());
+    let (o, _) = run_program(
+        PanicStateRead,
+        PanicStateRead,
+        empty_sol_set(),
+        0,
+        Arc::new(p),
+        empty_prgm_ctx(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(o, Some(ProgramOutput::Satisfied(false)));
+
+    // Satisfied false 3
+    let p = Program(asm::to_bytes([PUSH(3)]).collect());
+    let (o, _) = run_program(
+        PanicStateRead,
+        PanicStateRead,
+        empty_sol_set(),
+        0,
+        Arc::new(p),
+        empty_prgm_ctx(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(o, Some(ProgramOutput::Satisfied(false)));
+
+    // Memory
+    let p = Program(
+        asm::to_bytes([PUSH(42), PUSH(43), PUSH(2), PUSH(2), ALOC, STOR, PUSH(2)]).collect(),
+    );
+    let (o, _) = run_program(
+        PanicStateRead,
+        PanicStateRead,
+        empty_sol_set(),
+        0,
+        Arc::new(p),
+        empty_prgm_ctx(),
+    )
+    .await
+    .unwrap();
+    let mem = vec![42, 43].try_into().unwrap();
+    assert_eq!(o, Some(ProgramOutput::DataOutput(DataOutput::Memory(mem))));
+}
+
+fn empty_sol_set() -> Arc<SolutionSet> {
+    Arc::new(SolutionSet {
+        solutions: vec![Solution {
+            predicate_to_solve: PredicateAddress {
+                contract: ContentAddress([0; 32]),
+                predicate: ContentAddress([0; 32]),
+            },
+            predicate_data: vec![],
+            state_mutations: vec![],
+        }],
+    })
+}
+
+fn empty_prgm_ctx() -> ProgramCtx {
+    ProgramCtx {
+        parents: vec![],
+        children: vec![],
+        reads: Default::default(),
+    }
+}
+
+struct PanicStateRead;
+
+impl StateRead for PanicStateRead {
+    type Error = String;
+
+    type Future = std::future::Ready<Result<Vec<Vec<Word>>, Self::Error>>;
+
+    fn key_range(
+        &self,
+        _contract_addr: ContentAddress,
+        _key: Key,
+        _num_values: usize,
+    ) -> Self::Future {
+        panic!("StateRead::key_range called")
+    }
+}

--- a/crates/check/tests/solution.rs
+++ b/crates/check/tests/solution.rs
@@ -6,7 +6,7 @@ use essential_hash::content_addr;
 use essential_types::{
     contract::Contract,
     predicate::{Edge, Node, Predicate, Program, Reads},
-    solution::{Mutation, Solution, SolutionSet},
+    solution::{encode::encode_mutations, Mutation, Solution, SolutionSet},
     ContentAddress, PredicateAddress, Word,
 };
 use std::{collections::HashMap, sync::Arc};
@@ -615,4 +615,129 @@ async fn solution_outputs() {
             ]
         }
     );
+}
+
+#[tokio::test]
+async fn solution_compute_mutations() {
+    use essential_vm::asm::short::*;
+    let _ = tracing_subscriber::fmt::try_init();
+    let mutations_0 = vec![Mutation {
+        key: vec![1, 2, 3, 4],
+        value: vec![42],
+    }];
+    let mutations_1 = vec![
+        Mutation {
+            key: vec![5, 6, 7, 8],
+            value: vec![43, 44],
+        },
+        Mutation {
+            key: vec![9],
+            value: vec![45, 46],
+        },
+    ];
+    let mutations_2 = vec![
+        Mutation {
+            key: vec![10, 11],
+            value: vec![47, 48, 49],
+        },
+        Mutation {
+            key: vec![12],
+            value: vec![50, 51],
+        },
+    ];
+    let encoded_mutations_0 = encode_mutations(&mutations_0).collect::<Vec<_>>();
+    let encoded_mutations_1 = encode_mutations(&mutations_1).collect::<Vec<_>>();
+    let encoded_mutations_2 = encode_mutations(&mutations_2).collect::<Vec<_>>();
+
+    let make_prog = |encoded_mutations: Vec<Word>| {
+        let encoded_mutations_len = encoded_mutations.len();
+        let mut p = encoded_mutations.into_iter().map(PUSH).collect::<Vec<_>>();
+        p.push(PUSH(encoded_mutations_len as Word));
+        p.push(PUSH(encoded_mutations_len as Word));
+        p.push(ALOC);
+        p.push(STOR);
+        p.push(PUSH(2));
+        Program(asm::to_bytes(p).collect())
+    };
+
+    let pred_0_prg_0 = make_prog(encoded_mutations_0.clone());
+    let pred_0_prg_1 = make_prog(encoded_mutations_1.clone());
+    let pred_1_prg_0 = make_prog(encoded_mutations_2.clone());
+
+    let pred_0_prg_0_ca = content_addr(&pred_0_prg_0);
+    let pred_0_prg_1_ca = content_addr(&pred_0_prg_1);
+    let pred_1_prg_0_ca = content_addr(&pred_1_prg_0);
+
+    let node = |program_address, edge_start| Node {
+        program_address,
+        edge_start,
+        reads: Reads::Pre, // unused for this test.
+    };
+    let nodes = vec![
+        node(pred_0_prg_0_ca.clone(), Edge::MAX),
+        node(pred_0_prg_1_ca.clone(), Edge::MAX),
+    ];
+    let edges = vec![];
+    let predicate_0 = Predicate { nodes, edges };
+    let contract_0 = Contract::without_salt(vec![predicate_0]);
+    let pred_addr_0 = PredicateAddress {
+        contract: content_addr(&contract_0),
+        predicate: content_addr(&contract_0.predicates[0]),
+    };
+
+    let nodes = vec![node(pred_1_prg_0_ca.clone(), Edge::MAX)];
+    let edges = vec![];
+    let predicate_1 = Predicate { nodes, edges };
+    let contract_1 = Contract::without_salt(vec![predicate_1]);
+    let pred_addr_1 = PredicateAddress {
+        contract: content_addr(&contract_1),
+        predicate: content_addr(&contract_1.predicates[0]),
+    };
+
+    // Create a solution that "solves" our predicate.
+    let set = SolutionSet {
+        solutions: vec![
+            Solution {
+                predicate_to_solve: pred_addr_1.clone(),
+                predicate_data: Default::default(),
+                state_mutations: vec![],
+            },
+            Solution {
+                predicate_to_solve: pred_addr_0.clone(),
+                predicate_data: Default::default(),
+                state_mutations: vec![],
+            },
+        ],
+    };
+
+    let predicate_0 = Arc::new(contract_0.predicates[0].clone());
+    let predicate_1 = Arc::new(contract_1.predicates[0].clone());
+    let mut map = HashMap::new();
+    map.insert(pred_addr_0.contract.clone(), predicate_0);
+    map.insert(pred_addr_1.contract.clone(), predicate_1);
+
+    let get_predicate = |addr: &PredicateAddress| map.get(&addr.contract).unwrap().clone();
+    let programs: HashMap<ContentAddress, Arc<Program>> = vec![
+        (pred_0_prg_0_ca, Arc::new(pred_0_prg_0)),
+        (pred_0_prg_1_ca, Arc::new(pred_0_prg_1)),
+        (pred_1_prg_0_ca, Arc::new(pred_1_prg_0)),
+    ]
+    .into_iter()
+    .collect();
+    let get_program: Arc<HashMap<_, _>> = Arc::new(programs);
+
+    let set = solution::check_and_compute_solution_set(
+        &State::EMPTY,
+        &State::EMPTY,
+        set,
+        get_predicate,
+        get_program,
+        Arc::new(solution::CheckPredicateConfig::default()),
+    )
+    .await
+    .unwrap();
+
+    let expected = [mutations_0, mutations_1].concat();
+    assert_eq!(set.1.solutions[0].state_mutations, mutations_2);
+    assert_eq!(set.1.solutions[1].state_mutations, expected);
 }

--- a/crates/types/src/fmt.rs
+++ b/crates/types/src/fmt.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     predicate::{PredicateDecodeError, PredicateEncodeError},
+    solution::decode::MutationDecodeError,
     ContentAddress, PredicateAddress, Signature,
 };
 use core::{fmt, str};
@@ -89,6 +90,19 @@ impl fmt::Display for PredicateEncodeError {
             match self {
                 PredicateEncodeError::TooManyNodes => "too many nodes",
                 PredicateEncodeError::TooManyEdges => "too many edges",
+            }
+        )
+    }
+}
+
+impl fmt::Display for MutationDecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                MutationDecodeError::WordsTooShort =>
+                    "bytes too short for lengths given for key or value",
             }
         )
     }

--- a/crates/types/src/solution/decode.rs
+++ b/crates/types/src/solution/decode.rs
@@ -1,0 +1,79 @@
+//! # Decoding
+//! Decoding for solution types.
+
+use crate::Word;
+
+use super::Mutation;
+
+#[cfg(test)]
+mod tests;
+
+/// Errors that can occur when decoding a predicate.
+#[derive(Debug, PartialEq)]
+pub enum MutationDecodeError {
+    /// The words are too short for the lengths of the key or value.
+    WordsTooShort,
+}
+
+impl std::error::Error for MutationDecodeError {}
+
+/// Decode a mutation from words.
+///
+/// # Layout
+/// ```text
+/// +-----------------+-----------------+
+/// | key length      | key             |
+/// +-----------------+-----------------+
+/// | value length    | value           |
+/// +-----------------+-----------------+
+/// ```
+pub fn decode_mutation(bytes: &[Word]) -> Result<Mutation, MutationDecodeError> {
+    if bytes.len() < 2 {
+        return Err(MutationDecodeError::WordsTooShort);
+    }
+    // Saturating cast
+    let key_len: usize = bytes[0].try_into().unwrap_or(usize::MAX);
+    if bytes.len() < 1 + key_len {
+        return Err(MutationDecodeError::WordsTooShort);
+    }
+    let key = bytes[1..1 + key_len].to_vec();
+    // Saturating cast
+    let value_len: usize = bytes[1 + key_len].try_into().unwrap_or(usize::MAX);
+
+    if bytes.len() < 2 + key_len + value_len {
+        return Err(MutationDecodeError::WordsTooShort);
+    }
+    let value = bytes[2 + key_len..2 + key_len + value_len].to_vec();
+    Ok(Mutation { key, value })
+}
+
+/// Decode a slice of mutations from words.
+///
+/// # Layout
+/// ```text
+/// +-----------------+-----------------+-----------------+-----------------+
+/// | num mutations   | mutation 1      | mutation 2      | ...             |
+/// +-----------------+-----------------+-----------------+-----------------+
+/// ```
+pub fn decode_mutations(bytes: &[Word]) -> Result<Vec<Mutation>, MutationDecodeError> {
+    if bytes.is_empty() {
+        return Err(MutationDecodeError::WordsTooShort);
+    }
+    // Saturating cast
+    let len: usize = bytes[0].try_into().unwrap_or(usize::MAX);
+    let mut mutations = Vec::with_capacity(len);
+    if len == 0 {
+        return Ok(mutations);
+    }
+    let mut i = 1;
+    while i < bytes.len() {
+        let Some(b) = bytes.get(i..) else {
+            return Err(MutationDecodeError::WordsTooShort);
+        };
+        let mutation = decode_mutation(b)?;
+        let size = mutation.encode_size();
+        i += size;
+        mutations.push(mutation);
+    }
+    Ok(mutations)
+}

--- a/crates/types/src/solution/decode/tests.rs
+++ b/crates/types/src/solution/decode/tests.rs
@@ -1,0 +1,23 @@
+use super::*;
+
+#[test]
+fn test_decode_mutation() {
+    let words = vec![3, 1, 2, 3, 2, 4, 5];
+    let m = decode_mutation(&words).unwrap();
+    assert_eq!(m.key, vec![1, 2, 3]);
+    assert_eq!(m.value, vec![4, 5]);
+
+    let words = vec![4, 1, 2, 3, 2, 4, 5];
+    decode_mutation(&words).expect_err("Value length too short");
+}
+
+#[test]
+fn test_decode_mutations() {
+    let words = vec![2, 3, 1, 2, 3, 2, 4, 5, 2, 6, 7, 3, 8, 9, 10];
+    let m = decode_mutations(&words).unwrap();
+    assert_eq!(m.len(), 2);
+    assert_eq!(m[0].key, vec![1, 2, 3]);
+    assert_eq!(m[0].value, vec![4, 5]);
+    assert_eq!(m[1].key, vec![6, 7]);
+    assert_eq!(m[1].value, vec![8, 9, 10]);
+}

--- a/crates/types/src/solution/encode.rs
+++ b/crates/types/src/solution/encode.rs
@@ -1,0 +1,51 @@
+//! # Encoding
+//! Encoding for solution types.
+use crate::Word;
+
+use super::Mutation;
+
+#[cfg(test)]
+mod tests;
+
+/// Returns the size in words of the encoded mutation.
+///
+/// 2 words for the key length and value length,
+/// plus the length of the key and value data.
+pub fn encode_mutation_size(mutation: &Mutation) -> usize {
+    2 + mutation.key.len() + mutation.value.len()
+}
+
+/// Encodes a mutation into a sequence of words.
+///
+/// # Layout
+/// ```text
+/// +-----------------+-----------------+
+/// | key length      | key             |
+/// +-----------------+-----------------+
+/// | value length    | value           |
+/// +-----------------+-----------------+
+/// ```
+pub fn encode_mutation(mutation: &Mutation) -> impl Iterator<Item = Word> + use<'_> {
+    // Saturating cast
+    let key_len: Word = mutation.key.len().try_into().unwrap_or(Word::MAX);
+    // Saturating cast
+    let value_len: Word = mutation.value.len().try_into().unwrap_or(Word::MAX);
+    std::iter::once(key_len)
+        .chain(mutation.key.iter().copied())
+        .chain(std::iter::once(value_len))
+        .chain(mutation.value.iter().copied())
+}
+
+/// Encodes a slice of mutations into a sequence of words.
+///
+/// # Layout
+/// ```text
+/// +-----------------+-----------------+-----------------+-----------------+
+/// | num mutations   | mutation 1      | mutation 2      | ...             |
+/// +-----------------+-----------------+-----------------+-----------------+
+/// ```
+pub fn encode_mutations(mutations: &[Mutation]) -> impl Iterator<Item = Word> + use<'_> {
+    // Saturating cast
+    let len: Word = mutations.len().try_into().unwrap_or(Word::MAX);
+    std::iter::once(len).chain(mutations.iter().flat_map(encode_mutation))
+}

--- a/crates/types/src/solution/encode/tests.rs
+++ b/crates/types/src/solution/encode/tests.rs
@@ -1,0 +1,38 @@
+use crate::solution::decode::{decode_mutation, decode_mutations};
+
+use super::*;
+
+#[test]
+fn test_encode_mutation() {
+    let m = Mutation {
+        key: vec![1, 2, 3],
+        value: vec![4, 5],
+    };
+    let words = encode_mutation(&m).collect::<Vec<_>>();
+    assert_eq!(words, vec![3, 1, 2, 3, 2, 4, 5]);
+
+    // Round trip
+    let m2 = decode_mutation(&words).unwrap();
+    assert_eq!(m, m2);
+}
+
+#[test]
+fn test_encode_mutations() {
+    let m = vec![
+        Mutation {
+            key: vec![1, 2, 3],
+            value: vec![4, 5],
+        },
+        Mutation {
+            key: vec![6, 7],
+            value: vec![8, 9, 10],
+        },
+    ];
+
+    let words = encode_mutations(&m).collect::<Vec<_>>();
+    assert_eq!(words, vec![2, 3, 1, 2, 3, 2, 4, 5, 2, 6, 7, 3, 8, 9, 10]);
+
+    // Round trip
+    let m2 = decode_mutations(&words).unwrap();
+    assert_eq!(m, m2);
+}


### PR DESCRIPTION
The commits in this PR are very self contained. I strongly suggest reviewing each commit in order.

# Adds encoding and decoding for mutations and lists of mutations to and from words.
- Layout of a mutation is key_len, key..., value_len, value...
- Layout of a list of mutations is num_mutations, mutation 1, mutation 2, ...

closes #278

# Changes run_program to return a ProgramOutput
The output can be:
- Satisfied true. Indicated by stask[..] == [1]
- Satisfied false. Indicated by stack[..] != [1] && stack[..] != [2]
- DataOutput Memory. Indicated by stack[..] == [2]

closes #277 

# Changes check_predicate and check_set_predicate to return outputs
- Checks can now return data as part of their output.
- Each solution has a (possibly empty) vector of data outputs.
- Currently the only output is memory.

closes #279 
closes #280 

# Add check_and_compute_solution_set
- This function takes a solution set without mutations
and computes the mutations.
- It returns the modified `SolutionSet` with mutations.
- Mutations are encoded into memory and return with the
stack set to [2]

closes #281 

<!-- ps-id: 6c72cbcb-353b-4394-8910-ec62285f2c9e -->