### PR TITLE
VM changes

### DIFF
--- a/crates/vm/src/bytecode.rs
+++ b/crates/vm/src/bytecode.rs
@@ -39,15 +39,6 @@ pub struct BytecodeMappedSlice<'a, Op> {
     _op_ty: core::marker::PhantomData<Op>,
 }
 
-/// A type wrapper around `BytecodeMapped` that lazily constructs the map from
-/// the given bytecode as operations are accessed.
-pub struct BytecodeMappedLazy<Op, I> {
-    /// The `BytecodeMapped` instance that is lazily constructed.
-    pub(crate) mapped: BytecodeMapped<Op>,
-    /// The iterator yielding bytes.
-    pub(crate) iter: I,
-}
-
 impl<Op> BytecodeMapped<Op, Vec<u8>> {
     /// Push a single operation onto the bytecode mapping.
     pub fn push_op(&mut self, op: Op)
@@ -153,24 +144,6 @@ impl<'a, Op> BytecodeMappedSlice<'a, Op> {
         Op: TryFromBytes,
     {
         expect_ops_from_indices(self.bytecode, self.op_indices.iter().copied())
-    }
-}
-
-impl<Op, I> BytecodeMappedLazy<Op, I> {
-    /// Construct the `BytecodeMappedLazy` from its bytecode iterator.
-    pub fn new<J>(bytes: J) -> Self
-    where
-        J: IntoIterator<IntoIter = I>,
-        I: Iterator<Item = u8>,
-    {
-        let iter = bytes.into_iter();
-        let (min, _) = iter.size_hint();
-        let mapped = BytecodeMapped {
-            bytecode: Vec::with_capacity(min),
-            op_indices: Vec::with_capacity(min),
-            _op_ty: core::marker::PhantomData,
-        };
-        Self { mapped, iter }
     }
 }
 

--- a/crates/vm/src/lib.rs
+++ b/crates/vm/src/lib.rs
@@ -11,11 +11,10 @@
 //!
 //! ## Executing Ops
 //!
-//! There are three primary methods available for executing operations:
+//! There are two primary methods available for executing operations:
 //!
 //! - [`Vm::exec_ops`]
 //! - [`Vm::exec_bytecode`]
-//! - [`Vm::exec_bytecode_iter`]
 //!
 //! Each have slightly different performance implications, so be sure to read
 //! the docs before selecting a method.
@@ -103,8 +102,6 @@ pub(crate) mod utils {
 pub type BytecodeMapped<Bytes = Vec<u8>> = bytecode::BytecodeMapped<Op, Bytes>;
 /// Shorthand for the `BytecodeMappedSlice` type for mapping [`Op`]s.
 pub type BytecodeMappedSlice<'a> = bytecode::BytecodeMappedSlice<'a, Op>;
-/// Shorthand for the `BytecodeMappedLazy` type for mapping [`Op`]s.
-pub type BytecodeMappedLazy<I> = bytecode::BytecodeMappedLazy<Op, I>;
 
 /// Unit used to measure gas.
 pub type Gas = u64;
@@ -153,7 +150,7 @@ where
 /// In the error case, emits a debug log with the error.
 #[cfg(feature = "tracing")]
 pub(crate) fn trace_op_res<OA, T, E>(
-    oa: &mut OA,
+    oa: &OA,
     pc: usize,
     stack: &Stack,
     memory: &Memory,

--- a/crates/vm/src/repeat.rs
+++ b/crates/vm/src/repeat.rs
@@ -8,20 +8,20 @@ use crate::{
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 /// A stack of repeat counters.
 pub struct Repeat {
     stack: Vec<Slot>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 struct Slot {
     pub counter: Word,
     pub limit: Direction,
     pub repeat_index: usize,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 enum Direction {
     Up(Word),
     Down,

--- a/crates/vm/src/sync.rs
+++ b/crates/vm/src/sync.rs
@@ -48,7 +48,7 @@ where
 }
 
 /// Execute the given synchronous operations and return the resulting stack.
-pub fn exec<OA, S>(mut op_access: OA, access: Access, state: &S) -> ExecResult<Stack, S::Error>
+pub fn exec<OA, S>(op_access: OA, access: Access, state: &S) -> ExecResult<Stack, S::Error>
 where
     OA: OpAccess<Op = Op>,
     OA::Error: Into<OpError<S::Error>>,
@@ -60,7 +60,7 @@ where
         let res = step_op(access.clone(), op, &mut vm, state);
 
         #[cfg(feature = "tracing")]
-        crate::trace_op_res(&mut op_access, vm.pc, &vm.stack, &vm.memory, &res);
+        crate::trace_op_res(&op_access, vm.pc, &vm.stack, &vm.memory, &res);
 
         let update = match res {
             Ok(update) => update,

--- a/crates/vm/src/vm.rs
+++ b/crates/vm/src/vm.rs
@@ -9,7 +9,7 @@ use crate::{
 use std::sync::Arc;
 
 /// The operation execution state of the VM.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Vm {
     /// The program counter, i.e. index of the current operation within the program.
     pub pc: usize,
@@ -27,7 +27,7 @@ pub struct Vm {
     /// The repeat stack.
     pub repeat: Repeat,
     /// Lazily cached data for the VM.
-    pub cache: LazyCache,
+    pub cache: Arc<LazyCache>,
 }
 
 impl Vm {

--- a/crates/vm/tests/vm.rs
+++ b/crates/vm/tests/vm.rs
@@ -133,21 +133,6 @@ fn exec_method_behaviours_match() {
         .unwrap();
     assert_eq!(spent_sync_ops, spent_bc);
     assert_eq!(vm_sync_ops, vm_bc);
-
-    // Execute the same ops, but from a bytes iterator.
-    let bc_iter = mapped.bytecode().iter().copied();
-    let mut vm_bc_iter = Vm::default();
-    let spent_bc_iter = vm_bc_iter
-        .exec_bytecode_iter(
-            bc_iter,
-            test_access().clone(),
-            &State::EMPTY,
-            &|_: &Op| 1,
-            GasLimit::UNLIMITED,
-        )
-        .unwrap();
-    assert_eq!(spent_ops, spent_bc_iter);
-    assert_eq!(vm_ops, vm_bc_iter);
 }
 
 // Emulate the process of reading pre state, applying mutations to produce


### PR DESCRIPTION
Some changes to the VM in preparation for Compute and ComputeEnd ops (#262):
- `struct Vm` is `Clone`
- `trait OpAccess` takes `&self` instead of `&mut self`
  - This makes `struct BytecodeMappedLazy` and the related `exec_bytecode_iter` obsolete
  
Closes #271
Closes #274
