### PR TITLE
check program for post state

### DIFF
--- a/crates/asm/src/effects.rs
+++ b/crates/asm/src/effects.rs
@@ -1,4 +1,4 @@
-use crate::{Access, Op, StateRead};
+use crate::{Access, Op, Stack, StateRead, ToOpcode};
 use bitflags::bitflags;
 
 /// Flags representing the set of effects caused by a given slice of operations.
@@ -15,6 +15,10 @@ bitflags! {
         const ThisAddress = 1 << 2;
         /// Flag for [´Access::ThisContractAddress´]
         const ThisContractAddress = 1 << 3;
+        /// Flag for [´StateRead::PostKeyRange´]
+        const PostKeyRange = 1 << 4;
+        /// Flag for [´StateRead::PostKeyRangeExtern´]
+        const PostKeyRangeExtern = 1 << 5;
     }
 }
 
@@ -39,8 +43,55 @@ pub fn analyze(ops: &[Op]) -> Effects {
     effects
 }
 
+/// Analyze a slice of bytes to determine if it contains any of the effects.
+///
+/// This is a short-circuiting function that will return true if any of the effects
+/// are found in the byte slice.
+pub fn bytes_contains_any(bytes: &[u8], effects: Effects) -> bool {
+    let krng_byte: u8 = Op::StateRead(StateRead::KeyRange).to_opcode().into();
+    let krng_extern_byte: u8 = Op::StateRead(StateRead::KeyRangeExtern).to_opcode().into();
+    let post_krng_byte: u8 = Op::StateRead(StateRead::PostKeyRange).to_opcode().into();
+    let post_krng_extern_byte: u8 = Op::StateRead(StateRead::PostKeyRangeExtern)
+        .to_opcode()
+        .into();
+    let this_address_byte: u8 = Op::Access(Access::ThisAddress).to_opcode().into();
+    let this_contract_address_byte: u8 = Op::Access(Access::ThisContractAddress).to_opcode().into();
+
+    let push: u8 = Op::Stack(Stack::Push(0)).to_opcode().into();
+
+    let mut iter = bytes.iter();
+    while let Some(byte) = iter.next() {
+        match byte {
+            b if *b == krng_byte && effects.contains(Effects::KeyRange) => return true,
+            b if *b == krng_extern_byte && effects.contains(Effects::KeyRangeExtern) => {
+                return true
+            }
+            b if *b == post_krng_byte && effects.contains(Effects::PostKeyRange) => return true,
+            b if *b == post_krng_extern_byte && effects.contains(Effects::PostKeyRangeExtern) => {
+                return true
+            }
+            b if *b == this_address_byte && effects.contains(Effects::ThisAddress) => return true,
+            b if *b == this_contract_address_byte
+                && effects.contains(Effects::ThisContractAddress) =>
+            {
+                return true
+            }
+            b if *b == push => {
+                // Consume pushes arguments
+                iter.by_ref().take(8).for_each(|_| ());
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod test {
+    use essential_types::convert::word_from_bytes;
+
+    use crate::{effects::bytes_contains_any, ToOpcode};
+
     use super::{analyze, Access, Effects, Op, StateRead};
 
     #[test]
@@ -90,5 +141,61 @@ mod test {
         assert!(effects.contains(Effects::KeyRangeExtern));
         assert!(effects.contains(Effects::ThisAddress));
         assert!(effects.contains(Effects::ThisContractAddress));
+    }
+
+    #[test]
+    fn test_bytes_contains_any() {
+        use crate::short::*;
+        let to_bytes = |ops: &[Op]| crate::to_bytes(ops.iter().copied()).collect::<Vec<u8>>();
+
+        // No effects found
+        let effects = Effects::all();
+        assert!(!bytes_contains_any(&to_bytes(&[POP, POP, POP]), effects));
+
+        // Contains different effects
+        let effects = Effects::KeyRange | Effects::KeyRangeExtern;
+        assert!(!bytes_contains_any(&to_bytes(&[PKRNG, PKREX]), effects));
+
+        // Push contains key opcode
+        let key: u8 = PKRNG.to_opcode().into();
+        let bytes = [key, 0, 0, 0, 0, 0, 0, 0];
+        let word = word_from_bytes(bytes);
+        let effects = Effects::PostKeyRange;
+        assert!(!bytes_contains_any(&to_bytes(&[PUSH(word)]), effects));
+
+        // Push doesn't prevent detection
+        let effects = Effects::KeyRange;
+        assert!(bytes_contains_any(&to_bytes(&[PUSH(word), KRNG]), effects));
+
+        // Key range
+        let effects = Effects::KeyRange;
+        assert!(bytes_contains_any(&to_bytes(&[KRNG]), effects));
+
+        // Key range extern
+        let effects = Effects::KeyRangeExtern;
+        assert!(bytes_contains_any(&to_bytes(&[KREX]), effects));
+
+        // Post key range
+        let effects = Effects::PostKeyRange;
+        assert!(bytes_contains_any(&to_bytes(&[PKRNG]), effects));
+
+        // Post key range extern
+        let effects = Effects::PostKeyRangeExtern;
+        assert!(bytes_contains_any(&to_bytes(&[PKREX]), effects));
+
+        // This address
+        let effects = Effects::ThisAddress;
+        assert!(bytes_contains_any(&to_bytes(&[THIS]), effects));
+
+        // This contract address
+        let effects = Effects::ThisContractAddress;
+        assert!(bytes_contains_any(&to_bytes(&[THISC]), effects));
+
+        // Empty
+        let effects = Effects::empty();
+        assert!(!bytes_contains_any(&[], effects));
+
+        let effects = Effects::KeyRange;
+        assert!(!bytes_contains_any(&[], effects));
     }
 }

--- a/crates/check/benches/check_contract.rs
+++ b/crates/check/benches/check_contract.rs
@@ -32,6 +32,8 @@ pub fn bench(c: &mut Criterion) {
                     predicates.clone(),
                     programs.clone(),
                     config.clone(),
+                    Default::default(),
+                    &mut Default::default(),
                 )
             });
         });

--- a/crates/check/src/solution/test_graph_ops.rs
+++ b/crates/check/src/solution/test_graph_ops.rs
@@ -1,0 +1,342 @@
+use essential_types::predicate::{Edge, Node};
+
+use super::*;
+
+/// 0   1
+///  \ /
+///   2
+///  / \
+/// 3   4
+///  \ /
+///   5
+fn p() -> Predicate {
+    Predicate {
+        nodes: vec![
+            Node {
+                edge_start: 0,
+                program_address: ContentAddress([0; 32]),
+            },
+            Node {
+                edge_start: 1,
+                program_address: ContentAddress([1; 32]),
+            },
+            Node {
+                edge_start: 2,
+                program_address: ContentAddress([2; 32]),
+            },
+            Node {
+                edge_start: 4,
+                program_address: ContentAddress([3; 32]),
+            },
+            Node {
+                edge_start: 5,
+                program_address: ContentAddress([4; 32]),
+            },
+            Node {
+                edge_start: Edge::MAX,
+                program_address: ContentAddress([5; 32]),
+            },
+        ],
+        edges: vec![2, 2, 3, 4, 5, 5],
+    }
+}
+
+///   0
+///  / \
+/// 1   2
+/// |\  |
+/// 3 4 5
+///    \|
+///     6
+fn p3() -> Predicate {
+    Predicate {
+        nodes: vec![
+            Node {
+                edge_start: 0,
+                program_address: ContentAddress([0; 32]), // 0
+            },
+            Node {
+                edge_start: 2,
+                program_address: ContentAddress([1; 32]), // 1
+            },
+            Node {
+                edge_start: 4,
+                program_address: ContentAddress([2; 32]), // 2
+            },
+            Node {
+                edge_start: 5,
+                program_address: ContentAddress([4; 32]), // 3
+            },
+            Node {
+                edge_start: 6,
+                program_address: ContentAddress([5; 32]), // 4
+            },
+            Node {
+                edge_start: Edge::MAX,
+                program_address: ContentAddress([3; 32]), // 5
+            },
+            Node {
+                edge_start: Edge::MAX,
+                program_address: ContentAddress([6; 32]), // 6
+            },
+        ],
+        edges: vec![1, 2, 5, 3, 4, 6, 6],
+    }
+}
+
+/// Topological sort of a simple graph.
+/// Except parallel nodes are in their own inner list
+/// 0   1
+///  \ /
+///   2
+///  / \
+/// 3   4
+///  \ /
+///   5
+///
+/// [[0, 1], [2], [3, 4], [5]]
+#[test]
+fn test_parallel_top_sort() {
+    let predicate = p();
+    let parent_map = create_parent_map::<String>(&predicate).unwrap();
+
+    assert_eq!(
+        vec![vec![0, 1], vec![2], vec![3, 4], vec![5],],
+        parallel_topo_sort::<String>(&predicate, &parent_map).unwrap()
+    );
+}
+
+/// 0   1
+///  \ /
+///   2
+///  / \
+/// 3   4
+///  \ /
+///   5
+///
+/// {0: [], 1: [], 2: [0, 1], 3: [2], 4: [2], 5: [3, 4]}
+#[test]
+fn test_create_parent_map() {
+    let predicate = p();
+
+    let parent_map = create_parent_map::<String>(&predicate).unwrap();
+
+    let expected: BTreeMap<_, _> = [
+        (0, vec![]),
+        (1, vec![]),
+        (2, vec![0, 1]),
+        (3, vec![2]),
+        (4, vec![2]),
+        (5, vec![3, 4]),
+    ]
+    .into_iter()
+    .collect();
+
+    assert_eq!(expected, parent_map);
+
+    //   0[0]
+    //  /  \
+    // 1[1] 2[2]
+    // |   \    \
+    // 3[5] 4[3] 5[4]
+    //       \   |
+    //        6[6]
+    let predicate = p3();
+    let parent_map = create_parent_map::<String>(&predicate).unwrap();
+
+    let expected: BTreeMap<_, _> = [
+        (0, vec![]),
+        (1, vec![0]),
+        (2, vec![0]),
+        (3, vec![1]),
+        (4, vec![2]),
+        (5, vec![1]),
+        (6, vec![3, 4]),
+    ]
+    .into_iter()
+    .collect();
+
+    assert_eq!(expected, parent_map);
+}
+
+/// 0   1
+///  \ /
+///   2
+///  / \
+/// 3   4
+///  \ /
+///   5
+///
+/// {0: 0, 1: 0, 2: 2, 3: 1, 4: 1, 5: 2}
+#[test]
+fn test_in_degrees() {
+    let predicate = p();
+
+    let parent_map = create_parent_map::<String>(&predicate).unwrap();
+
+    let in_degrees = in_degrees(predicate.nodes.len(), &parent_map);
+
+    let expected: BTreeMap<_, _> = [(0, 0), (1, 0), (2, 2), (3, 1), (4, 1), (5, 2)]
+        .into_iter()
+        .collect();
+
+    assert_eq!(expected, in_degrees);
+}
+
+/// 0   1
+///  \ /
+///   2
+///  / \
+/// 3   4
+///  \ /
+///   5
+///
+/// {0: 0, 1: 0, 2: 2, 3: 1, 4: 1, 5: 2}
+/// {0: 0, 1: 0, 2: 1, 3: 1, 4: 1, 5: 2}
+#[test]
+fn test_reduce_in_degrees() {
+    let predicate = p();
+
+    let parent_map = create_parent_map::<String>(&predicate).unwrap();
+
+    let mut in_degrees = in_degrees(predicate.nodes.len(), &parent_map);
+
+    reduce_in_degrees(&mut in_degrees, predicate.node_edges(0).unwrap());
+
+    let expected: BTreeMap<_, _> = [(0, 0), (1, 0), (2, 1), (3, 1), (4, 1), (5, 2)]
+        .into_iter()
+        .collect();
+
+    assert_eq!(expected, in_degrees);
+}
+
+/// 0   1
+///  \ /
+///   2
+///  / \
+/// 3   4
+///  \ /
+///   5
+///
+/// [0, 1]
+#[test]
+fn test_find_nodes_with_no_parents() {
+    let predicate = p();
+
+    let parent_map = create_parent_map::<String>(&predicate).unwrap();
+
+    let in_degrees = in_degrees(predicate.nodes.len(), &parent_map);
+
+    let nodes = find_nodes_with_no_parents(&in_degrees);
+
+    assert_eq!(vec![0, 1], nodes);
+}
+
+/// 0   1
+///  \ /
+///   2
+///  / \
+/// 3   4
+/// |   |
+/// 5   6
+///  \ /
+///   7
+fn p2() -> Predicate {
+    Predicate {
+        nodes: vec![
+            Node {
+                edge_start: 0,
+                program_address: ContentAddress([0; 32]),
+            },
+            Node {
+                edge_start: 1,
+                program_address: ContentAddress([1; 32]),
+            },
+            Node {
+                edge_start: 2,
+                program_address: ContentAddress([2; 32]),
+            },
+            Node {
+                edge_start: 4,
+                program_address: ContentAddress([3; 32]),
+            },
+            Node {
+                edge_start: 5,
+                program_address: ContentAddress([4; 32]),
+            },
+            Node {
+                edge_start: 6,
+                program_address: ContentAddress([5; 32]),
+            },
+            Node {
+                edge_start: 7,
+                program_address: ContentAddress([6; 32]),
+            },
+            Node {
+                edge_start: Edge::MAX,
+                program_address: ContentAddress([7; 32]),
+            },
+        ],
+        edges: vec![2, 2, 3, 4, 5, 6, 7, 7],
+    }
+}
+
+/// 0   1
+///  \ /
+///   2
+///  / \
+/// 3  *4
+/// |   |
+/// 5   6
+///  \ /
+///   7
+///
+/// {4, 6, 7}
+#[test]
+fn test_find_deferred() {
+    let predicate = p2();
+
+    let f = |node: &Node| -> bool { node.program_address.0[0] == 4 };
+    let deferred = find_deferred(&predicate, f);
+
+    let expected: HashSet<_> = [4, 6, 7].into_iter().collect();
+    assert_eq!(expected, deferred);
+}
+
+/// 0   1
+///  \ /
+///   2
+///  / \
+/// 3  *4
+/// |   |
+/// 5   6
+///  \ /
+///   7
+///
+/// [0: false, 1: false, 2: true, 3: false, 4: false, 5: true, 6: false, 7: false]
+#[test]
+fn test_should_cache() {
+    let predicate = p2();
+    let deferred: HashSet<_> = [4, 6, 7].into_iter().collect();
+
+    let mut results = HashMap::new();
+    for node in 0..predicate.nodes.len() {
+        let r = should_cache(node as u16, &predicate, &deferred);
+        results.insert(node as u16, r);
+    }
+
+    let expected: HashMap<_, _> = [
+        (0, false),
+        (1, false),
+        (2, true),
+        (3, false),
+        (4, false),
+        (5, true),
+        (6, false),
+        (7, false),
+    ]
+    .into_iter()
+    .collect();
+
+    assert_eq!(expected, results);
+}

--- a/crates/check/src/solution/tests.rs
+++ b/crates/check/src/solution/tests.rs
@@ -1,62 +1,323 @@
 use super::*;
-use essential_types::predicate::Edge;
+use crate::vm::asm;
+use asm::short::*;
+use essential_types::predicate::{Edge, Node};
+
+type ContentAddr = u8;
+
+fn p(i: &[(ContentAddr, &[Edge])]) -> Arc<Predicate> {
+    let mut nodes = vec![];
+    let mut all_edges = vec![];
+    let mut last_edge_start = 0;
+    for (n, edges) in i {
+        let node = Node {
+            edge_start: if edges.is_empty() {
+                Edge::MAX
+            } else {
+                last_edge_start
+            },
+            program_address: ContentAddress([*n; 32]),
+        };
+        last_edge_start += edges.len() as u16;
+        nodes.push(node);
+        all_edges.extend_from_slice(edges);
+    }
+    Arc::new(Predicate {
+        nodes,
+        edges: all_edges,
+    })
+}
+
+type HasPost = bool;
+
+fn get_p(progs: &[(ContentAddr, HasPost)]) -> HashMap<ContentAddress, Arc<Program>> {
+    let mut progs_map = HashMap::new();
+    for (addr, has_post) in progs {
+        let program = if *has_post {
+            Program(asm::to_bytes([PKRNG]).collect())
+        } else {
+            Program(asm::to_bytes([POP]).collect())
+        };
+        progs_map.insert(ContentAddress([*addr; 32]), Arc::new(program));
+    }
+    progs_map
+}
+
+type NodeIx = u16;
+type StackV = Word;
+type MemV = Word;
+
+fn c(i: &[(NodeIx, &[StackV], &[MemV])]) -> Cache {
+    let mut cache = Cache::default();
+    for (node, stack, mem) in i {
+        cache.insert(*node, parent(stack, mem));
+    }
+    cache
+}
+
+fn parent(stack: &[StackV], mem: &[MemV]) -> Arc<(Stack, Memory)> {
+    let mut s = Stack::default();
+    let mut m = Memory::default();
+    for v in stack {
+        s.push(*v).unwrap();
+    }
+    m.alloc(mem.len() as i64).unwrap();
+    for (i, v) in mem.iter().enumerate() {
+        m.store(i as i64, *v).unwrap();
+    }
+    Arc::new((s, m))
+}
+
+fn make_mem(i: &[MemV]) -> Memory {
+    let mut m = Memory::default();
+    m.alloc(i.len() as i64).unwrap();
+    for (i, v) in i.iter().enumerate() {
+        m.store(i as i64, *v).unwrap();
+    }
+    m
+}
 
 #[test]
-fn test_check_predicate_sync_inner() {
-    let predicate = Predicate {
-        nodes: vec![],
-        edges: vec![],
+fn test_check_predicate_inner() {
+    // Sanity
+    let predicate = p(&[(0, &[1, 2]), (1, &[2]), (2, &[])]);
+    let get_program = get_p(&[(0, false), (1, false), (2, false)]);
+    let mut cache = c(&[]);
+    let ctx = Ctx {
+        run_mode: RunMode::Outputs,
+        cache: &mut cache,
     };
-    let predicate = Arc::new(predicate);
-    let run = |(ix, _): (&u16, &_)| {
-        (
-            *ix,
-            Result::<_, ProgramError<String>>::Ok((
-                Output::Leaf(ProgramOutput::Satisfied(true)),
-                0,
-            )),
-        )
+    let run = |ix, _| {
+        let o = match ix {
+            0 => Output::Parent(parent(&[], &[])),
+            1 => Output::Parent(parent(&[], &[])),
+            2 => Output::Leaf(ProgramOutput::Satisfied(true)),
+            _ => unreachable!(),
+        };
+        (ix, Ok::<_, ProgramError<String>>((o, 0)))
     };
-    let res = check_predicate_inner(run, predicate, &Default::default());
-    assert_eq!((0, vec![]), res.unwrap());
+    let (_, out) = check_predicate_inner(
+        run,
+        predicate.clone(),
+        &Default::default(),
+        &get_program,
+        ctx,
+    )
+    .unwrap();
+    assert!(out.is_empty());
+    assert!(cache.is_empty());
 
-    let predicate = Predicate {
-        nodes: vec![essential_types::predicate::Node {
-            edge_start: Edge::MAX,
-            program_address: ContentAddress([0; 32]),
-        }],
-        edges: vec![],
+    // Output on run output
+    let ctx = Ctx {
+        run_mode: RunMode::Outputs,
+        cache: &mut cache,
     };
-    let predicate = Arc::new(predicate);
-    let run = |(ix, _): (&u16, &_)| {
-        (
-            *ix,
-            Result::<_, ProgramError<String>>::Ok((
-                Output::Leaf(ProgramOutput::Satisfied(true)),
-                0,
-            )),
-        )
+    let run = |ix, _| {
+        let o = match ix {
+            0 => Output::Parent(parent(&[], &[])),
+            1 => Output::Parent(parent(&[], &[])),
+            2 => Output::Leaf(ProgramOutput::DataOutput(DataOutput::Memory(make_mem(&[
+                1, 2,
+            ])))),
+            _ => unreachable!(),
+        };
+        (ix, Ok::<_, ProgramError<String>>((o, 0)))
     };
-    let res = check_predicate_inner(run, predicate, &Default::default());
-    assert_eq!((0, vec![]), res.unwrap());
+    let (_, out) = check_predicate_inner(
+        run,
+        predicate.clone(),
+        &Default::default(),
+        &get_program,
+        ctx,
+    )
+    .unwrap();
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0], DataOutput::Memory(make_mem(&[1, 2])));
+    assert!(cache.is_empty());
 
-    let predicate = Predicate {
-        nodes: vec![essential_types::predicate::Node {
-            edge_start: Edge::MAX,
-            program_address: ContentAddress([0; 32]),
-        }],
-        edges: vec![],
+    // Nothing on checks run
+    let ctx = Ctx {
+        run_mode: RunMode::Checks,
+        cache: &mut cache,
     };
-    let predicate = Arc::new(predicate);
-    let run = |(ix, _): (&u16, &_)| {
-        (
-            *ix,
-            Result::<_, ProgramError<String>>::Ok((
-                Output::Parent(Arc::new((Default::default(), Default::default()))),
-                0,
-            )),
-        )
+    let (_, out) = check_predicate_inner(
+        run,
+        predicate.clone(),
+        &Default::default(),
+        &get_program,
+        ctx,
+    )
+    .unwrap();
+    assert!(out.is_empty());
+    assert!(cache.is_empty());
+
+    // False constraint fails on outputs run
+    let ctx = Ctx {
+        run_mode: RunMode::Outputs,
+        cache: &mut cache,
     };
-    let res = check_predicate_inner(run, predicate, &Default::default());
-    assert_eq!((0, vec![]), res.unwrap());
+    let run = |ix, _| {
+        let o = match ix {
+            0 => Output::Parent(parent(&[], &[])),
+            1 => Output::Parent(parent(&[], &[])),
+            2 => Output::Leaf(ProgramOutput::Satisfied(false)),
+            _ => unreachable!(),
+        };
+        (ix, Ok::<_, ProgramError<String>>((o, 0)))
+    };
+    check_predicate_inner(
+        run,
+        predicate.clone(),
+        &Default::default(),
+        &get_program,
+        ctx,
+    )
+    .unwrap_err();
+    assert!(cache.is_empty());
+
+    // False constraint is filtered out on checks run
+    let ctx = Ctx {
+        run_mode: RunMode::Checks,
+        cache: &mut cache,
+    };
+    let (_, out) = check_predicate_inner(
+        run,
+        predicate.clone(),
+        &Default::default(),
+        &get_program,
+        ctx,
+    )
+    .unwrap();
+    assert!(out.is_empty());
+    assert!(cache.is_empty());
+
+    //   0
+    //  / \
+    // 1   2
+    // |\  |
+    // 5 3 *4
+    //    \|
+    //     6
+    // 2 and 3 should cache
+    // 4 and 6 shouldn't run
+    let predicate = p(&[
+        (0, &[1, 2]),
+        (1, &[5, 3]),
+        (2, &[4]),
+        (3, &[6]),
+        (4, &[6]),
+        (5, &[]),
+        (6, &[]),
+    ]);
+    let get_program = get_p(&[
+        (0, false),
+        (1, false),
+        (2, false),
+        (3, false),
+        (4, true),
+        (5, false),
+        (6, false),
+    ]);
+
+    let mut cache = c(&[]);
+    let ctx = Ctx {
+        run_mode: RunMode::Outputs,
+        cache: &mut cache,
+    };
+    let run = |ix, inputs: Vec<Arc<(Stack, Memory)>>| {
+        match ix {
+            0 => assert!(inputs.is_empty()),
+            1 => {
+                assert_eq!(inputs.len(), 1);
+                assert_eq!(inputs[0], parent(&[], &[0]));
+            }
+            2 => {
+                assert_eq!(inputs.len(), 1);
+                assert_eq!(inputs[0], parent(&[], &[0]));
+            }
+            3 => {
+                assert_eq!(inputs.len(), 1);
+                assert_eq!(inputs[0], parent(&[], &[1]));
+            }
+            5 => {
+                assert_eq!(inputs.len(), 1);
+                assert_eq!(inputs[0], parent(&[], &[1]));
+            }
+            prog => panic!("Ran unexpected program {}", prog),
+        }
+        let o = match ix {
+            0 => Output::Parent(parent(&[], &[0])),
+            1 => Output::Parent(parent(&[], &[1])),
+            2 => Output::Parent(parent(&[], &[2])),
+            3 => Output::Parent(parent(&[], &[3])),
+            4 => Output::Parent(parent(&[], &[4])),
+            5 => Output::Leaf(ProgramOutput::DataOutput(DataOutput::Memory(make_mem(&[
+                5,
+            ])))),
+            6 => Output::Leaf(ProgramOutput::DataOutput(DataOutput::Memory(make_mem(&[
+                6,
+            ])))),
+            _ => unreachable!(),
+        };
+        (ix, Ok::<_, ProgramError<String>>((o, 0)))
+    };
+    let (_, out) = check_predicate_inner(
+        run,
+        predicate.clone(),
+        &Default::default(),
+        &get_program,
+        ctx,
+    )
+    .unwrap();
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0], DataOutput::Memory(make_mem(&[5])));
+    assert_eq!(cache.len(), 2);
+    assert_eq!(cache[&2], parent(&[], &[2]));
+    assert_eq!(cache[&3], parent(&[], &[3]));
+
+    let ctx = Ctx {
+        run_mode: RunMode::Checks,
+        cache: &mut cache,
+    };
+    let run = |ix, inputs: Vec<Arc<(Stack, Memory)>>| {
+        match ix {
+            4 => {
+                assert_eq!(inputs.len(), 1);
+                assert_eq!(inputs[0], parent(&[], &[2]));
+            }
+            6 => {
+                assert_eq!(inputs.len(), 2);
+                assert_eq!(inputs[0], parent(&[], &[3]));
+                assert_eq!(inputs[1], parent(&[], &[4]));
+            }
+            prog => panic!("Ran unexpected program {}", prog),
+        }
+        let o = match ix {
+            0 => Output::Parent(parent(&[], &[0])),
+            1 => Output::Parent(parent(&[], &[1])),
+            2 => Output::Parent(parent(&[], &[2])),
+            3 => Output::Parent(parent(&[], &[3])),
+            4 => Output::Parent(parent(&[], &[4])),
+            5 => Output::Leaf(ProgramOutput::DataOutput(DataOutput::Memory(make_mem(&[
+                5,
+            ])))),
+            6 => Output::Leaf(ProgramOutput::DataOutput(DataOutput::Memory(make_mem(&[
+                6,
+            ])))),
+            _ => unreachable!(),
+        };
+        (ix, Ok::<_, ProgramError<String>>((o, 0)))
+    };
+    let (_, out) = check_predicate_inner(
+        run,
+        predicate.clone(),
+        &Default::default(),
+        &get_program,
+        ctx,
+    )
+    .unwrap();
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0], DataOutput::Memory(make_mem(&[6])));
+
+    assert_eq!(cache.len(), 2);
 }

--- a/crates/check/tests/encoding.rs
+++ b/crates/check/tests/encoding.rs
@@ -99,6 +99,8 @@ fn test_encoding_sig_and_pub_key() {
         get_predicate,
         get_program,
         Default::default(),
+        Default::default(),
+        &mut Default::default(),
     )
     .unwrap();
 }

--- a/crates/check/tests/solution.rs
+++ b/crates/check/tests/solution.rs
@@ -203,6 +203,8 @@ fn predicate_graph_stack_passing() {
         get_predicate,
         get_program,
         Arc::new(solution::CheckPredicateConfig::default()),
+        Default::default(),
+        &mut Default::default(),
     )
     .unwrap();
 
@@ -342,6 +344,8 @@ fn predicate_graph_memory_passing() {
         get_predicate,
         get_program,
         Arc::new(solution::CheckPredicateConfig::default()),
+        Default::default(),
+        &mut Default::default(),
     )
     .unwrap();
 
@@ -491,6 +495,8 @@ fn predicate_graph_state_read() {
         get_predicate,
         get_program,
         Arc::new(solution::CheckPredicateConfig::default()),
+        Default::default(),
+        &mut Default::default(),
     )
     .unwrap();
 
@@ -583,6 +589,8 @@ fn solution_outputs() {
         get_predicate,
         get_program,
         Arc::new(solution::CheckPredicateConfig::default()),
+        Default::default(),
+        &mut Default::default(),
     )
     .unwrap();
 
@@ -721,6 +729,8 @@ fn solution_compute_mutations() {
         get_predicate,
         get_program,
         Arc::new(solution::CheckPredicateConfig::default()),
+        Default::default(),
+        &mut Default::default(),
     )
     .unwrap();
 

--- a/crates/check/tests/throughput.rs
+++ b/crates/check/tests/throughput.rs
@@ -102,6 +102,8 @@ fn test_throughput() {
                 get_predicate,
                 get_program.clone(),
                 config.clone(),
+                Default::default(),
+                &mut Default::default(),
             )
             .unwrap();
             assert!(outputs.gas > 0);

--- a/crates/vm/benches/eval.rs
+++ b/crates/vm/benches/eval.rs
@@ -1,17 +1,16 @@
-use std::collections::HashSet;
+use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use essential_asm as asm;
 use essential_asm::Op;
 use essential_types::{ContentAddress, PredicateAddress, Solution, SolutionSet};
-use essential_vm::{Access, GasLimit, Vm};
+use essential_vm::{bytecode::BytecodeMapped, Access, GasLimit, Vm};
 
 #[path = "../tests/util.rs"]
 mod util;
 use util::State;
 
 pub fn bench(c: &mut Criterion) {
-    let mutable_keys = HashSet::with_capacity(0);
     let solution_set = SolutionSet {
         solutions: vec![Solution {
             predicate_to_solve: PredicateAddress {
@@ -22,8 +21,9 @@ pub fn bench(c: &mut Criterion) {
             state_mutations: vec![],
         }],
     };
+    let solutions = Arc::new(solution_set.solutions.clone());
 
-    let access = Access::new(&solution_set, 0, &mutable_keys);
+    let access = Access::new(solutions, 0);
 
     let bytes = [asm::Stack::Push(1).into(), asm::Stack::Pop.into()];
     let mut vm = Vm::default();
@@ -31,12 +31,13 @@ pub fn bench(c: &mut Criterion) {
         let mut bytes: Vec<Op> = bytes.iter().cycle().take(i).copied().collect();
         bytes.push(asm::Stack::Push(1).into());
         let bytes: Vec<_> = asm::to_bytes(bytes).collect();
+        let bytecode = BytecodeMapped::try_from(&bytes[..]).unwrap();
         let op_gas_cost = &|_: &Op| 1;
         c.bench_function(&format!("push_pop_{}", i), |b| {
             b.iter(|| {
-                vm.exec_bytecode_iter(
-                    bytes.iter().copied(),
-                    access,
+                vm.exec_bytecode(
+                    &bytecode,
+                    access.clone(),
                     &State::EMPTY,
                     op_gas_cost,
                     GasLimit::UNLIMITED,


### PR DESCRIPTION
## check program for post state
- Adds function to check a function for any post state reads

## run mode and cache
- Adds in check_predicate_inner (see docs for info)
- Cache is global and can be used across runs
- There are two run modes, outputs or checks

Add two pass run
- First pass generates outputs and ignores post state reads
- Second pass checks outputs by only running the post state reads and
  their children.
- Any parents from the first pass are cached.

closes #306 
closes #307 
closes #308 
closes #310 
closes #311 

<!-- ps-id: 37afbf9d-0263-49ff-8c45-cd0b4253cfc7 -->